### PR TITLE
fix!: bump metrics version to 4.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ Powertools is available in Maven Central. You can use your favourite dependency 
     <dependency>
         <groupId>software.amazon.lambda</groupId>
         <artifactId>powertools-tracing</artifactId>
-        <version>1.12.3</version>
+        <version>2.0.0-beta</version>
     </dependency>
     <dependency>
         <groupId>software.amazon.lambda</groupId>
         <artifactId>powertools-logging</artifactId>
-        <version>1.12.3</version>
+        <version>2.0.0-beta</version>
     </dependency>
     <dependency>
         <groupId>software.amazon.lambda</groupId>
         <artifactId>powertools-metrics</artifactId>
-        <version>1.12.3</version>
+        <version>2.0.0-beta</version>
     </dependency>
     ...
 </dependencies>

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -89,8 +89,12 @@ You can create metrics using `putMetric`, and manually create dimensions for all
         @Override
         @Metrics(namespace = "ExampleApplication", service = "booking")
         public Object handleRequest(Object input, Context context) {
-            metricsLogger.putDimensions(DimensionSet.of("environment", "prod"));
-            metricsLogger.putMetric("SuccessfulBooking", 1, Unit.COUNT);
+            try {
+                metricsLogger.putDimensions(DimensionSet.of("environment", "prod"));
+                metricsLogger.putMetric("SuccessfulBooking", 1, Unit.COUNT);
+            } catch (InvalidDimensionException | InvalidMetricException | DimensionSetExceededException e) {
+                LOG.error(e);
+            }
             ...
         }
     }
@@ -173,8 +177,12 @@ You can use `putMetadata` for advanced use cases, where you want to metadata as 
         @Override
         @Metrics(namespace = "ServerlessAirline", service = "payment")
         public Object handleRequest(Object input, Context context) {
-            metricsLogger().putMetric("CustomMetric1", 1, Unit.COUNT);
-            metricsLogger().putMetadata("booking_id", "1234567890");
+            try {
+                metricsLogger().putMetadata("booking_id", "1234567890");
+                metricsLogger().putMetric("CustomMetric1", 1, Unit.COUNT);
+            } catch (InvalidMetricException e) {
+                throw new RuntimeException(e);
+            }
             ...
         }
     }
@@ -199,7 +207,11 @@ Dimension, it can be done via `#!java MetricsUtils.defaultDimensions()`.
         MetricsLogger metricsLogger = MetricsUtils.metricsLogger();
         
         static {
-            MetricsUtils.defaultDimensions(DimensionSet.of("CustomDimension", "booking"));
+            try {
+                MetricsUtils.defaultDimensions(DimensionSet.of("CustomDimension", "booking"));
+            } catch (InvalidDimensionException | DimensionSetExceededException e) {
+                throw new RuntimeException(e);
+            }
         }
     
         @Override
@@ -228,8 +240,12 @@ CloudWatch EMF uses the same dimensions across all your metrics. Use `withSingle
 
         @Override
         public Object handleRequest(Object input, Context context) {
-             withSingleMetric("CustomMetrics2", 1, Unit.COUNT, "Another", (metric) -> {
-                metric.setDimensions(DimensionSet.of("AnotherService", "CustomService"));
+            withSingleMetric("CustomMetrics2", 1, Unit.COUNT, "Another", (metric) -> {
+                try {
+                    metric.setDimensions(DimensionSet.of("AnotherService", "CustomService"));
+                } catch (InvalidDimensionException | DimensionSetExceededException e) {
+                    throw new RuntimeException(e);
+                }
             });
         }
     }

--- a/docs/utilities/sqs_large_message_handling.md
+++ b/docs/utilities/sqs_large_message_handling.md
@@ -144,7 +144,7 @@ To disable deletion of payloads setting the following annotation parameter:
 ## Utility
 
 If you want to avoid using annotation and have control over error that can happen during payload enrichment use `SqsUtils.enrichedMessageFromS3()`.
-It provides you access with list of `SQSMessage` object enriched from S3 payload.
+It provides you access with a list of `SQSMessage` object enriched from S3 payload.
 
 Original `SQSEvent` object is never mutated. You can also control if the S3 payload should be deleted after successful
 processing.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,7 +76,7 @@ extra_javascript:
 
 extra:
   powertools:
-    version: 1.12.3
+    version: 2.0.0-beta
 
 repo_url: https://github.com/awslabs/aws-lambda-powertools-java
 edit_uri: edit/master/docs

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <log4j.version>2.19.0</log4j.version>
         <jackson.version>2.13.4.2</jackson.version>
         <aspectj.version>1.9.7</aspectj.version>
-        <aws.sdk.version>2.18.9</aws.sdk.version>
+        <aws.sdk.version>2.18.13</aws.sdk.version>
         <aws.xray.recorder.version>2.12.0</aws.xray.recorder.version>
         <payloadoffloading-common.version>2.1.2</payloadoffloading-common.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <log4j.version>2.19.0</log4j.version>
         <jackson.version>2.14.0</jackson.version>
         <aspectj.version>1.9.7</aspectj.version>
-        <aws.sdk.version>2.18.13</aws.sdk.version>
+        <aws.sdk.version>2.18.19</aws.sdk.version>
         <aws.xray.recorder.version>2.13.0</aws.xray.recorder.version>
         <payloadoffloading-common.version>2.1.2</payloadoffloading-common.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <log4j.version>2.19.0</log4j.version>
         <jackson.version>2.14.0</jackson.version>
         <aspectj.version>1.9.7</aspectj.version>
-        <aws.sdk.version>2.18.19</aws.sdk.version>
+        <aws.sdk.version>2.18.22</aws.sdk.version>
         <aws.xray.recorder.version>2.13.0</aws.xray.recorder.version>
         <payloadoffloading-common.version>2.1.2</payloadoffloading-common.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -457,7 +457,7 @@
                     <plugin>
                         <groupId>com.github.spotbugs</groupId>
                         <artifactId>spotbugs-maven-plugin</artifactId>
-                        <version>4.7.2.1</version>
+                        <version>4.7.3.0</version>
                         <executions>
                             <execution>
                                 <id>test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <jackson.version>2.14.0</jackson.version>
         <aspectj.version>1.9.7</aspectj.version>
         <aws.sdk.version>2.18.13</aws.sdk.version>
-        <aws.xray.recorder.version>2.12.0</aws.xray.recorder.version>
+        <aws.xray.recorder.version>2.13.0</aws.xray.recorder.version>
         <payloadoffloading-common.version>2.1.2</payloadoffloading-common.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <lambda.core.version>1.2.1</lambda.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <log4j.version>2.19.0</log4j.version>
-        <jackson.version>2.14.0</jackson.version>
+        <jackson.version>2.14.1</jackson.version>
         <aspectj.version>1.9.7</aspectj.version>
         <aws.sdk.version>2.18.22</aws.sdk.version>
         <aws.xray.recorder.version>2.13.0</aws.xray.recorder.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>software.amazon.lambda</groupId>
     <artifactId>powertools-parent</artifactId>
-    <version>1.12.3</version>
+    <version>2.0.0-beta</version>
     <packaging>pom</packaging>
 
     <name>AWS Lambda Powertools for Java library Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <aws.xray.recorder.version>2.13.0</aws.xray.recorder.version>
         <payloadoffloading-common.version>2.1.2</payloadoffloading-common.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <lambda.core.version>1.2.1</lambda.core.version>
+        <lambda.core.version>1.2.2</lambda.core.version>
         <lambda.events.version>3.11.0</lambda.events.version>
         <lambda.serial.version>1.0.0</lambda.serial.version>
         <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-inline</artifactId>
-                <version>4.8.1</version>
+                <version>4.9.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>4.8.1</version>
+                <version>4.9.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <junit-jupiter.version>5.9.1</junit-jupiter.version>
-        <aws-embedded-metrics.version>1.0.6</aws-embedded-metrics.version>
+        <aws-embedded-metrics.version>4.0.3</aws-embedded-metrics.version>
         <jmespath.version>0.5.1</jmespath.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <log4j.version>2.19.0</log4j.version>
-        <jackson.version>2.13.4.2</jackson.version>
+        <jackson.version>2.14.0</jackson.version>
         <aspectj.version>1.9.7</aspectj.version>
         <aws.sdk.version>2.18.13</aws.sdk.version>
         <aws.xray.recorder.version>2.12.0</aws.xray.recorder.version>

--- a/powertools-cloudformation/pom.xml
+++ b/powertools-cloudformation/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>powertools-parent</artifactId>
         <groupId>software.amazon.lambda</groupId>
-        <version>1.12.3</version>
+        <version>2.0.0-beta</version>
     </parent>
 
     <name>AWS Lambda Powertools for Java library Cloudformation</name>

--- a/powertools-core/pom.xml
+++ b/powertools-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>powertools-parent</artifactId>
         <groupId>software.amazon.lambda</groupId>
-        <version>1.12.3</version>
+        <version>2.0.0-beta</version>
     </parent>
 
     <name>AWS Lambda Powertools for Java library Core</name>

--- a/powertools-idempotency/pom.xml
+++ b/powertools-idempotency/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>software.amazon.lambda</groupId>
         <artifactId>powertools-parent</artifactId>
-        <version>1.12.3</version>
+        <version>2.0.0-beta</version>
     </parent>
 
     <artifactId>powertools-idempotency</artifactId>

--- a/powertools-idempotency/pom.xml
+++ b/powertools-idempotency/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.junit-pioneer</groupId>
             <artifactId>junit-pioneer</artifactId>
-            <version>1.7.1</version>
+            <version>1.9.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/powertools-logging/pom.xml
+++ b/powertools-logging/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>powertools-parent</artifactId>
         <groupId>software.amazon.lambda</groupId>
-        <version>1.12.3</version>
+        <version>2.0.0-beta</version>
     </parent>
 
     <name>AWS Lambda Powertools for Java library Logging</name>

--- a/powertools-metrics/pom.xml
+++ b/powertools-metrics/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>powertools-parent</artifactId>
         <groupId>software.amazon.lambda</groupId>
-        <version>1.12.3</version>
+        <version>2.0.0-beta</version>
     </parent>
 
     <name>AWS Lambda Powertools for Java library Metrics</name>

--- a/powertools-metrics/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsLoggerHelper.java
+++ b/powertools-metrics/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsLoggerHelper.java
@@ -1,10 +1,13 @@
 package software.amazon.cloudwatchlogs.emf.model;
 
+import software.amazon.cloudwatchlogs.emf.exception.DimensionSetExceededException;
+
 import java.lang.reflect.Field;
 
 import static software.amazon.lambda.powertools.metrics.MetricsUtils.metricsLogger;
 
 public final class MetricsLoggerHelper {
+
     private MetricsLoggerHelper() {
     }
 
@@ -13,7 +16,11 @@ public final class MetricsLoggerHelper {
     }
 
     public static long dimensionsCount() {
-        return metricsContext().getDimensions().size();
+        try {
+            return metricsContext().getDimensions().size();
+        } catch (DimensionSetExceededException e) {
+            throw new RuntimeException("Too many dimensions defined", e);
+        }
     }
 
     public static MetricsContext metricsContext() {

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsColdStartEnabledHandler.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsColdStartEnabledHandler.java
@@ -2,6 +2,7 @@ package software.amazon.lambda.powertools.metrics.handlers;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import software.amazon.cloudwatchlogs.emf.exception.InvalidMetricException;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 import software.amazon.lambda.powertools.metrics.Metrics;
@@ -14,7 +15,11 @@ public class PowertoolsMetricsColdStartEnabledHandler implements RequestHandler<
     @Metrics(namespace = "ExampleApplication", service = "booking", captureColdStart = true)
     public Object handleRequest(Object input, Context context) {
         MetricsLogger metricsLogger = metricsLogger();
-        metricsLogger.putMetric("Metric1", 1, Unit.BYTES);
+        try {
+            metricsLogger.putMetric("Metric1", 1, Unit.BYTES);
+        } catch (InvalidMetricException e) {
+            throw new RuntimeException(e);
+        }
 
         return null;
     }

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsEnabledDefaultDimensionHandler.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsEnabledDefaultDimensionHandler.java
@@ -2,6 +2,9 @@ package software.amazon.lambda.powertools.metrics.handlers;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import software.amazon.cloudwatchlogs.emf.exception.DimensionSetExceededException;
+import software.amazon.cloudwatchlogs.emf.exception.InvalidDimensionException;
+import software.amazon.cloudwatchlogs.emf.exception.InvalidMetricException;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
@@ -14,14 +17,23 @@ import static software.amazon.lambda.powertools.metrics.MetricsUtils.withSingleM
 public class PowertoolsMetricsEnabledDefaultDimensionHandler implements RequestHandler<Object, Object> {
 
     static {
-        defaultDimensions(DimensionSet.of("CustomDimension", "booking"));
+        try {
+            defaultDimensions(DimensionSet.of("CustomDimension", "booking"));
+        } catch (InvalidDimensionException | DimensionSetExceededException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
     @Metrics(namespace = "ExampleApplication", service = "booking")
     public Object handleRequest(Object input, Context context) {
         MetricsLogger metricsLogger = metricsLogger();
-        metricsLogger.putMetric("Metric1", 1, Unit.BYTES);
+
+        try {
+            metricsLogger.putMetric("Metric1", 1, Unit.BYTES);
+        } catch (InvalidMetricException e) {
+            throw new RuntimeException(e);
+        }
 
         withSingleMetric("Metric2", 1, Unit.COUNT, log -> {});
 

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsEnabledDefaultNoDimensionHandler.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsEnabledDefaultNoDimensionHandler.java
@@ -2,6 +2,7 @@ package software.amazon.lambda.powertools.metrics.handlers;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import software.amazon.cloudwatchlogs.emf.exception.InvalidMetricException;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 import software.amazon.lambda.powertools.metrics.Metrics;
@@ -20,7 +21,11 @@ public class PowertoolsMetricsEnabledDefaultNoDimensionHandler implements Reques
     @Metrics(namespace = "ExampleApplication", service = "booking")
     public Object handleRequest(Object input, Context context) {
         MetricsLogger metricsLogger = metricsLogger();
-        metricsLogger.putMetric("Metric1", 1, Unit.BYTES);
+        try {
+            metricsLogger.putMetric("Metric1", 1, Unit.BYTES);
+        } catch (InvalidMetricException e) {
+            throw new RuntimeException(e);
+        }
 
         withSingleMetric("Metric2", 1, Unit.COUNT, log -> {});
 

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsEnabledHandler.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsEnabledHandler.java
@@ -2,6 +2,9 @@ package software.amazon.lambda.powertools.metrics.handlers;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import software.amazon.cloudwatchlogs.emf.exception.DimensionSetExceededException;
+import software.amazon.cloudwatchlogs.emf.exception.InvalidDimensionException;
+import software.amazon.cloudwatchlogs.emf.exception.InvalidMetricException;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
@@ -16,11 +19,20 @@ public class PowertoolsMetricsEnabledHandler implements RequestHandler<Object, O
     @Metrics(namespace = "ExampleApplication", service = "booking")
     public Object handleRequest(Object input, Context context) {
         MetricsLogger metricsLogger = metricsLogger();
-        metricsLogger.putMetric("Metric1", 1, Unit.BYTES);
-
+        try {
+            metricsLogger.putMetric("Metric1", 1, Unit.BYTES);
+        } catch (InvalidMetricException e) {
+            throw new RuntimeException(e);
+        }
 
         withSingleMetric("Metric2", 1, Unit.COUNT,
-                log -> log.setDimensions(DimensionSet.of("Dimension1", "Value1")));
+                log -> {
+                    try {
+                        log.setDimensions(DimensionSet.of("Dimension1", "Value1"));
+                    } catch (InvalidDimensionException | DimensionSetExceededException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
 
         return null;
     }

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsEnabledStreamHandler.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsEnabledStreamHandler.java
@@ -5,6 +5,7 @@ import java.io.OutputStream;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import software.amazon.cloudwatchlogs.emf.exception.InvalidMetricException;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 import software.amazon.lambda.powertools.metrics.Metrics;
@@ -17,6 +18,10 @@ public class PowertoolsMetricsEnabledStreamHandler implements RequestStreamHandl
     @Metrics(namespace = "ExampleApplication", service = "booking")
     public void handleRequest(InputStream input, OutputStream output, Context context) {
         MetricsLogger metricsLogger = metricsLogger();
-        metricsLogger.putMetric("Metric1", 1, Unit.BYTES);
+        try {
+            metricsLogger.putMetric("Metric1", 1, Unit.BYTES);
+        } catch (InvalidMetricException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsNoDimensionsHandler.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsNoDimensionsHandler.java
@@ -2,6 +2,7 @@ package software.amazon.lambda.powertools.metrics.handlers;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import software.amazon.cloudwatchlogs.emf.exception.InvalidMetricException;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.lambda.powertools.metrics.Metrics;
@@ -14,7 +15,11 @@ public class PowertoolsMetricsNoDimensionsHandler implements RequestHandler<Obje
     @Metrics(namespace = "ExampleApplication", service = "booking")
     public Object handleRequest(Object input, Context context) {
         MetricsLogger metricsLogger = metricsLogger();
-        metricsLogger.putMetric("CoolMetric", 1);
+        try {
+            metricsLogger.putMetric("CoolMetric", 1);
+        } catch (InvalidMetricException e) {
+            throw new RuntimeException(e);
+        }
         metricsLogger.setDimensions(new DimensionSet());
 
         return null;

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsTooManyDimensionsHandler.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsTooManyDimensionsHandler.java
@@ -4,6 +4,8 @@ import java.util.stream.IntStream;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import software.amazon.cloudwatchlogs.emf.exception.DimensionSetExceededException;
+import software.amazon.cloudwatchlogs.emf.exception.InvalidDimensionException;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.lambda.powertools.metrics.Metrics;
@@ -13,12 +15,20 @@ import static software.amazon.lambda.powertools.metrics.MetricsUtils.metricsLogg
 public class PowertoolsMetricsTooManyDimensionsHandler implements RequestHandler<Object, Object> {
 
     @Override
-    @Metrics
+    @Metrics(namespace = "ExampleApplication", service = "booking")
     public Object handleRequest(Object input, Context context) {
         MetricsLogger metricsLogger = metricsLogger();
 
+
+
         metricsLogger.setDimensions(IntStream.range(1, 15)
-                .mapToObj(value -> DimensionSet.of("Dimension" + value, "DimensionValue" + value))
+                .mapToObj(value -> {
+                    try {
+                        return DimensionSet.of("Dimension" + value, "DimensionValue" + value);
+                    } catch (InvalidDimensionException | DimensionSetExceededException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
                 .toArray(DimensionSet[]::new));
 
         return null;

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsWithExceptionInHandler.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsWithExceptionInHandler.java
@@ -2,6 +2,7 @@ package software.amazon.lambda.powertools.metrics.handlers;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import software.amazon.cloudwatchlogs.emf.exception.InvalidMetricException;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.lambda.powertools.metrics.Metrics;
 
@@ -13,7 +14,11 @@ public class PowertoolsMetricsWithExceptionInHandler implements RequestHandler<O
     @Metrics(namespace = "ExampleApplication", service = "booking")
     public Object handleRequest(Object input, Context context) {
         MetricsLogger metricsLogger = metricsLogger();
-        metricsLogger.putMetric("CoolMetric", 1);
+        try {
+            metricsLogger.putMetric("CoolMetric", 1);
+        } catch (InvalidMetricException e) {
+            throw new RuntimeException(e);
+        }
         throw new IllegalStateException("Whoops, unexpected exception");
     }
 }

--- a/powertools-parameters/pom.xml
+++ b/powertools-parameters/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>powertools-parent</artifactId>
         <groupId>software.amazon.lambda</groupId>
-        <version>1.12.3</version>
+        <version>2.0.0-beta</version>
     </parent>
 
     <artifactId>powertools-parameters</artifactId>

--- a/powertools-parameters/src/main/java/software/amazon/lambda/powertools/parameters/cache/DataStore.java
+++ b/powertools-parameters/src/main/java/software/amazon/lambda/powertools/parameters/cache/DataStore.java
@@ -46,7 +46,8 @@ public class DataStore {
     }
 
     public Object get(String key) {
-        return store.containsKey(key)?store.get(key).value:null;
+        ValueNode node = store.get(key);
+        return node != null ? node.value : null;
     }
 
     public boolean hasExpired(String key, Instant now) {

--- a/powertools-serialization/pom.xml
+++ b/powertools-serialization/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>powertools-parent</artifactId>
         <groupId>software.amazon.lambda</groupId>
-        <version>1.12.3</version>
+        <version>2.0.0-beta</version>
     </parent>
 
     <artifactId>powertools-serialization</artifactId>

--- a/powertools-sqs/pom.xml
+++ b/powertools-sqs/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>powertools-parent</artifactId>
         <groupId>software.amazon.lambda</groupId>
-        <version>1.12.3</version>
+        <version>2.0.0-beta</version>
     </parent>
 
     <name>AWS Lambda Powertools for Java library SQS</name>

--- a/powertools-sqs/src/main/java/software/amazon/lambda/powertools/sqs/internal/BatchContext.java
+++ b/powertools-sqs/src/main/java/software/amazon/lambda/powertools/sqs/internal/BatchContext.java
@@ -114,7 +114,7 @@ public final class BatchContext {
                     map(SQSMessage::getMessageId)
                     .collect(toList());
 
-            LOG.debug(format("[%s] records failed processing, but exceptions are suppressed. " +
+            LOG.debug(format("[%d] records failed processing, but exceptions are suppressed. " +
                     "Failed messages %s", failedMessages.size(), messageIds));
         } else {
             throw new SQSBatchProcessingException(exceptions, failedMessages, successReturns);

--- a/powertools-test-suite/pom.xml
+++ b/powertools-test-suite/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>powertools-parent</artifactId>
         <groupId>software.amazon.lambda</groupId>
-        <version>1.12.3</version>
+        <version>2.0.0-beta</version>
     </parent>
 
     <name>AWS Lambda Powertools for Java library Test Suite</name>

--- a/powertools-tracing/pom.xml
+++ b/powertools-tracing/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>powertools-parent</artifactId>
         <groupId>software.amazon.lambda</groupId>
-        <version>1.12.3</version>
+        <version>2.0.0-beta</version>
     </parent>
 
     <name>AWS Lambda Powertools for Java library Tracing</name>

--- a/powertools-validation/pom.xml
+++ b/powertools-validation/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>powertools-parent</artifactId>
         <groupId>software.amazon.lambda</groupId>
-        <version>1.12.3</version>
+        <version>2.0.0-beta</version>
     </parent>
 
     <name>AWS Lambda Powertools for Java validation library</name>

--- a/powertools-validation/src/main/java/software/amazon/lambda/powertools/validation/ValidationUtils.java
+++ b/powertools-validation/src/main/java/software/amazon/lambda/powertools/validation/ValidationUtils.java
@@ -239,12 +239,17 @@ public class ValidationUtils {
      * @return the loaded json schema
      */
     public static JsonSchema getJsonSchema(String schema, boolean validateSchema) {
-        JsonSchema jsonSchema = schemas.get(schema);
+        JsonSchema jsonSchema = schemas.computeIfAbsent(schema, ValidationUtils::createJsonSchema);
 
-        if (jsonSchema != null) {
-            return jsonSchema;
+        if (validateSchema) {
+            validateSchema(schema, jsonSchema);
         }
 
+        return jsonSchema;
+    }
+
+    private static JsonSchema createJsonSchema(String schema) {
+        JsonSchema jsonSchema;
         if (schema.startsWith(CLASSPATH)) {
             String filePath = schema.substring(CLASSPATH.length());
             try (InputStream schemaStream = ValidationAspect.class.getResourceAsStream(filePath)) {
@@ -260,19 +265,17 @@ public class ValidationUtils {
             jsonSchema = ValidationConfig.get().getFactory().getSchema(schema);
         }
 
-        if (validateSchema) {
-            String version = ValidationConfig.get().getSchemaVersion().toString();
-            try {
-                validate(jsonSchema.getSchemaNode(),
-                        getJsonSchema("classpath:/schemas/meta_schema_" + version));
-            } catch (ValidationException ve) {
-                throw new IllegalArgumentException("The schema " + schema + " is not valid, it does not respect the specification " + version, ve);
-            }
-        }
-
-        schemas.put(schema, jsonSchema);
-
         return jsonSchema;
+    }
+
+    private static void validateSchema(String schema, JsonSchema jsonSchema) {
+        String version = ValidationConfig.get().getSchemaVersion().toString();
+        try {
+            validate(jsonSchema.getSchemaNode(),
+                    getJsonSchema("classpath:/schemas/meta_schema_" + version));
+        } catch (ValidationException ve) {
+            throw new IllegalArgumentException("The schema " + schema + " is not valid, it does not respect the specification " + version, ve);
+        }
     }
 
     /**

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -121,6 +121,10 @@
                 <Method name="objectMapper"/>
             </And>
             <And>
+                <Class name="software.amazon.lambda.powertools.metrics.MetricsUtils"/>
+                <Method name="metricsLogger"/>
+            </And>
+            <And>
                 <Class name="software.amazon.lambda.powertools.sqs.SqsUtils"/>
                 <Method name="objectMapper"/>
             </And>


### PR DESCRIPTION
**Issue #, if available:** #944

## Description of changes:

Update `aws-embedded-metrics` version to v4.0.3 (latest) and adjust the code to handle this bump (from v1.0.6)

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

**BREAKING CHANGE**

This new version of `aws-embedded-metrics` introduce Checked Exception for multiple methods (`metricsLogger.putMetric()`, `DimensionSet.of()`, ...). Lambda Powertools internally catch them and throws Unchecked Exceptions, but when using the library itself in the Lambda handler, it is now required to handle this exception.

Example:

Before: 
```
metricsLogger.putMetric("CoolMetric", 1);
```

After:
```
try {
    metricsLogger.putMetric("CoolMetric", 1);
} catch (InvalidMetricException e) {
    log.error(e);
}
```

Questions: 
- should powertools-metrics also throw these checked exceptions?
- Or on the contrary, should powertools-metrics provide a wrapper for the MetricsLogger and hide these exceptions?

Developer Experience is quite bad with these checked exception, with a lot of try catch everywhere in the code...

**RFC issue #**: #944

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
