### PR TITLE
chore: add all java versions and use corretto for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,12 +42,12 @@ on:
       - 'examples/pom.xml'
       - '.github/workflows/**'
 jobs:
-  build:
+  build-corretto:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 5
       matrix:
-        java: [8, 9, 10, 11, 12, 13, 15, 16, 17, 18, 19, 20 ]
+        java: [8, 11, 15, 16, 17, 18, 19, 20 ]
     name: Java ${{ matrix.java }}
     env:
       JAVA: ${{ matrix.java }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,10 +45,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
+      max-parallel: 5
       matrix:
-        # test against latest update of each major Java version, as well as specific updates of LTS versions:
-        java: [8, 8.0.192, 11.0.x, 11.0.3, 12, 13, 15, 16, 17 ]
+        java: [8, 9, 10, 11, 12, 13, 15, 16, 17, 18, 19, 20 ]
     name: Java ${{ matrix.java }}
     env:
       JAVA: ${{ matrix.java }}
@@ -56,9 +55,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'corretto'
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Build with Maven

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         run: mvn -Pbuild-without-spotbugs -B package --file pom.xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # 3.1.1
-        if: ${{ matrix.java == '11.0.x' }} # publish results once
+        if: ${{ matrix.java == '11' }} # publish results once
         with:
           files: ./powertools-cloudformation/target/site/jacoco/jacoco.xml,./powertools-core/target/site/jacoco/jacoco.xml,./powertools-idempotency/target/site/jacoco/jacoco.xml,./powertools-logging/target/site/jacoco/jacoco.xml,./powertools-metrics/target/site/jacoco/jacoco.xml,./powertools-parameters/target/site/jacoco/jacoco.xml,./powertools-serialization/target/site/jacoco/jacoco.xml,./powertools-sqs/target/site/jacoco/jacoco.xml,./powertools-tracing/target/site/jacoco/jacoco.xml,./powertools-validation/target/site/jacoco/jacoco.xml
   savepr:


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Change the github build workflow to use corretto and build with all Java versions from 8 to 20.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
