### PR TITLE
chore: Reporting size of the jars in GitHub comments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,14 +77,15 @@ jobs:
         id: artifacts-size-report
         if: ${{ matrix.java == '11.0.x' }} # do it once
         run: |
-          echo '## Artifacts Size Report' > report.md
-          echo '| Module | Version | Size |' >> report.md
+          echo '## :floppy_disk: Artifacts Size Report' > report.md
+          echo '| Module | Version | Size (KB) |' >> report.md
           echo '| --- | --- | --- |' >> report.md
           artifact_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           for artifact in $(cat target/powertools-parent-*.buildinfo | grep 'outputs.*.jar' | grep -v 'sources.jar'); do
             artifact_name=$(echo "$artifact" | cut -d '=' -f2)
             artifact_name=${artifact_name%-$artifact_version.jar}
             artifact_size=$(grep "${artifact%%.filename*}.length" target/powertools-parent-*.buildinfo | cut -d '=' -f2)
+            artifact_size=$((artifact_size/1000))
             echo "| ${artifact_name} | ${artifact_version} | ${artifact_size} |" >> report.md
           done
       - name: Find potential existing report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,34 @@ jobs:
         if: ${{ matrix.java == '11' }} # publish results once
         with:
           files: ./powertools-cloudformation/target/site/jacoco/jacoco.xml,./powertools-core/target/site/jacoco/jacoco.xml,./powertools-idempotency/target/site/jacoco/jacoco.xml,./powertools-logging/target/site/jacoco/jacoco.xml,./powertools-metrics/target/site/jacoco/jacoco.xml,./powertools-parameters/target/site/jacoco/jacoco.xml,./powertools-serialization/target/site/jacoco/jacoco.xml,./powertools-sqs/target/site/jacoco/jacoco.xml,./powertools-tracing/target/site/jacoco/jacoco.xml,./powertools-validation/target/site/jacoco/jacoco.xml
+      - name: Get artifacts size & build report
+        id: artifacts-size-report
+        if: ${{ matrix.java == '11.0.x' }} # do it once
+        run: |
+          report='## Artifacts Size Report\n\n'
+          report+='| Module | Version | Size |\n'
+          report+='| --- | --- | --- |\n'
+          artifact_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          grep 'outputs.*.jar' target/powertools-parent-*.buildinfo | grep -v 'sources.jar' | while IFS= read -r artifact; do
+            artifact_name=$(echo "$artifact" | cut -d '=' -f2)
+            artifact_name=${artifact_name%-$artifact_version.jar}
+            artifact_size=$(grep "${artifact%%.filename*}.length" target/powertools-parent-*.buildinfo | cut -d '=' -f2)
+            echo "$artifact_name = $artifact_size"
+            report+="| $artifact_name | $artifact_version | $artifact_size |\n"
+          done
+          echo "ARTIFACT_REPORT=$report" >> "$GITHUB_OUTPUT"
+      - name: Comment artifacts size report
+        if: ${{ matrix.java == '11.0.x' }} # do it once
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: ${{ steps.artifacts-size-report.outputs.ARTIFACT_REPORT }}
+            })
+
   savepr:
     runs-on: ubuntu-latest
     name: Save PR number if running on PR by dependabot

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: ${{ steps.artifacts-size-report.outputs.ARTIFACT_REPORT }}
+              body: "${{ steps.artifacts-size-report.outputs.ARTIFACT_REPORT }}"
             })
 
   savepr:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,18 +89,22 @@ jobs:
             report+="| ${artifact_name} | ${artifact_version} | ${artifact_size} |\n"
           done
           echo "ARTIFACT_REPORT=$report" >> "$GITHUB_OUTPUT"
-      - name: Comment artifacts size report
+      - name: Find potential existing report
         if: ${{ matrix.java == '11.0.x' }} # do it once
-        uses: actions/github-script@v6
+        uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1 # 2.4.0
+        id: find-comment
         with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: "${{ steps.artifacts-size-report.outputs.ARTIFACT_REPORT }}"
-            })
-
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Artifacts Size Report
+      - name: Artifacts size report in comment
+        if: ${{ matrix.java == '11.0.x' }} # do it once
+        uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa # 3.0.2
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: "${{ steps.artifacts-size-report.outputs.ARTIFACT_REPORT }}"
+          edit-mode: replace
   savepr:
     runs-on: ubuntu-latest
     name: Save PR number if running on PR by dependabot

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
             artifact_name=${artifact_name%-$artifact_version.jar}
             artifact_size=$(grep "${artifact%%.filename*}.length" target/powertools-parent-*.buildinfo | cut -d '=' -f2)
             echo "$artifact_name = $artifact_size"
-            report+="| $artifact_name | $artifact_version | $artifact_size |\n"
+            report+="| ${artifact_name} | ${artifact_version} | ${artifact_size} |\n"
           done
           echo "ARTIFACT_REPORT=$report" >> "$GITHUB_OUTPUT"
       - name: Comment artifacts size report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,15 +78,15 @@ jobs:
         if: ${{ matrix.java == '11.0.x' }} # do it once
         run: |
           report='## Artifacts Size Report\n\n'
-          report+='| Module | Size |\n'
-          report+='| --- | --- |\n'
+          report+='| Module | Version | Size |\n'
+          report+='| --- | --- | --- |\n'
           artifact_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           grep 'outputs.*.jar' target/powertools-parent-*.buildinfo | grep -v 'sources.jar' | while IFS= read -r artifact; do
             artifact_name=$(echo "$artifact" | cut -d '=' -f2)
             artifact_name=${artifact_name%-$artifact_version.jar}
             artifact_size=$(grep "${artifact%%.filename*}.length" target/powertools-parent-*.buildinfo | cut -d '=' -f2)
             echo "$artifact_name = $artifact_size"
-            report+="| ${artifact_name} | ${artifact_size} |\n"
+            report+="\| ${artifact_name} \| ${artifact_version} \| ${artifact_size} \|\n"
           done
           echo "ARTIFACT_REPORT=$report" >> "$GITHUB_OUTPUT"
       - name: Comment artifacts size report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,18 +77,16 @@ jobs:
         id: artifacts-size-report
         if: ${{ matrix.java == '11.0.x' }} # do it once
         run: |
-          report='## Artifacts Size Report\n\n'
-          report+='| Module | Version | Size |\n'
-          report+='| --- | --- | --- |\n'
+          echo '## Artifacts Size Report' > report.md
+          echo '| Module | Version | Size |' >> report.md
+          echo '| --- | --- | --- |' >> report.md
           artifact_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           for artifact in $(cat target/powertools-parent-*.buildinfo | grep 'outputs.*.jar' | grep -v 'sources.jar'); do
             artifact_name=$(echo "$artifact" | cut -d '=' -f2)
             artifact_name=${artifact_name%-$artifact_version.jar}
             artifact_size=$(grep "${artifact%%.filename*}.length" target/powertools-parent-*.buildinfo | cut -d '=' -f2)
-            echo "$artifact_name = $artifact_size"
-            report+="| ${artifact_name} | ${artifact_version} | ${artifact_size} |\n"
+            echo "| ${artifact_name} | ${artifact_version} | ${artifact_size} |" >> report.md
           done
-          echo "ARTIFACT_REPORT=$report" >> "$GITHUB_OUTPUT"
       - name: Find potential existing report
         if: ${{ matrix.java == '11.0.x' }} # do it once
         uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1 # 2.4.0
@@ -97,13 +95,13 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: Artifacts Size Report
-      - name: Artifacts size report in comment
+      - name: Write artifacts size report in comment
         if: ${{ matrix.java == '11.0.x' }} # do it once
         uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa # 3.0.2
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
-          body: "${{ steps.artifacts-size-report.outputs.ARTIFACT_REPORT }}"
+          body-path: 'report.md'
           edit-mode: replace
   savepr:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,15 +78,15 @@ jobs:
         if: ${{ matrix.java == '11.0.x' }} # do it once
         run: |
           report='## Artifacts Size Report\n\n'
-          report+='| Module | Version | Size |\n'
-          report+='| --- | --- | --- |\n'
+          report+='| Module | Size |\n'
+          report+='| --- | --- |\n'
           artifact_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           grep 'outputs.*.jar' target/powertools-parent-*.buildinfo | grep -v 'sources.jar' | while IFS= read -r artifact; do
             artifact_name=$(echo "$artifact" | cut -d '=' -f2)
             artifact_name=${artifact_name%-$artifact_version.jar}
             artifact_size=$(grep "${artifact%%.filename*}.length" target/powertools-parent-*.buildinfo | cut -d '=' -f2)
             echo "$artifact_name = $artifact_size"
-            report+="| ${artifact_name} | ${artifact_version} | ${artifact_size} |\n"
+            report+="| ${artifact_name} | ${artifact_size} |\n"
           done
           echo "ARTIFACT_REPORT=$report" >> "$GITHUB_OUTPUT"
       - name: Comment artifacts size report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,8 +85,7 @@ jobs:
             artifact_name=$(echo "$artifact" | cut -d '=' -f2)
             artifact_name=${artifact_name%-$artifact_version.jar}
             artifact_size=$(grep "${artifact%%.filename*}.length" target/powertools-parent-*.buildinfo | cut -d '=' -f2)
-            artifact_size=$((artifact_size/1000))
-            echo "| ${artifact_name} | ${artifact_version} | ${artifact_size} |" >> report.md
+            printf "| %s | %s | %.2f |\n" "$artifact_name" "$artifact_version" "$(bc <<< "scale=2; $artifact_size/1000")" >> report.md
           done
       - name: Find potential existing report
         if: ${{ matrix.java == '11.0.x' }} # do it once

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,12 +81,12 @@ jobs:
           report+='| Module | Version | Size |\n'
           report+='| --- | --- | --- |\n'
           artifact_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          grep 'outputs.*.jar' target/powertools-parent-*.buildinfo | grep -v 'sources.jar' | while IFS= read -r artifact; do
+          for artifact in $(cat target/powertools-parent-*.buildinfo | grep 'outputs.*.jar' | grep -v 'sources.jar'); do
             artifact_name=$(echo "$artifact" | cut -d '=' -f2)
             artifact_name=${artifact_name%-$artifact_version.jar}
             artifact_size=$(grep "${artifact%%.filename*}.length" target/powertools-parent-*.buildinfo | cut -d '=' -f2)
             echo "$artifact_name = $artifact_size"
-            report+="\| ${artifact_name} \| ${artifact_version} \| ${artifact_size} \|\n"
+            report+="| ${artifact_name} | ${artifact_version} | ${artifact_size} |\n"
           done
           echo "ARTIFACT_REPORT=$report" >> "$GITHUB_OUTPUT"
       - name: Comment artifacts size report

--- a/.github/workflows/pr_artifacts_size.yml
+++ b/.github/workflows/pr_artifacts_size.yml
@@ -1,0 +1,57 @@
+name: Artifacts Size
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'powertools-cloudformation/**'
+      - 'powertools-core/**'
+      - 'powertools-serialization/**'
+      - 'powertools-logging/**'
+      - 'powertools-sqs/**'
+      - 'powertools-tracing/**'
+      - 'powertools-validation/**'
+      - 'powertools-parameters/**'
+      - 'powertools-idempotency/**'
+      - 'powertools-metrics/**'
+      - 'pom.xml'
+jobs:
+  codecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Setup java JDK 11
+        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # v3.11.0
+        with:
+          distribution: 'corretto'
+          java-version: 11
+      - name: Build with Maven
+        run: mvn clean package --file pom.xml -DskipTests
+      - name: Get artifacts size & build report
+        id: artifacts-size-report
+        run: |
+          echo '## :floppy_disk: Artifacts Size Report' > report.md
+          echo '| Module | Version | Size (KB) |' >> report.md
+          echo '| --- | --- | --- |' >> report.md
+          artifact_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          for artifact in $(cat target/powertools-parent-*.buildinfo | grep 'outputs.*.jar' | grep -v 'sources.jar'); do
+            artifact_name=$(echo "$artifact" | cut -d '=' -f2)
+            artifact_name=${artifact_name%-$artifact_version.jar}
+            artifact_size=$(grep "${artifact%%.filename*}.length" target/powertools-parent-*.buildinfo | cut -d '=' -f2)
+            printf "| %s | %s | %.2f |\n" "$artifact_name" "$artifact_version" "$(bc <<< "scale=2; $artifact_size/1000")" >> report.md
+          done
+      - name: Find potential existing report
+        uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1 # 2.4.0
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Artifacts Size Report
+      - name: Write artifacts size report in comment
+        uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa # 3.0.2
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: 'report.md'
+          edit-mode: replace

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -73,36 +73,6 @@ jobs:
         if: ${{ matrix.java == '11' }} # publish results once
         with:
           files: ./powertools-cloudformation/target/site/jacoco/jacoco.xml,./powertools-core/target/site/jacoco/jacoco.xml,./powertools-idempotency/target/site/jacoco/jacoco.xml,./powertools-logging/target/site/jacoco/jacoco.xml,./powertools-metrics/target/site/jacoco/jacoco.xml,./powertools-parameters/target/site/jacoco/jacoco.xml,./powertools-serialization/target/site/jacoco/jacoco.xml,./powertools-sqs/target/site/jacoco/jacoco.xml,./powertools-tracing/target/site/jacoco/jacoco.xml,./powertools-validation/target/site/jacoco/jacoco.xml
-      - name: Get artifacts size & build report
-        id: artifacts-size-report
-        if: ${{ matrix.java == '11.0.x' }} # do it once
-        run: |
-          echo '## :floppy_disk: Artifacts Size Report' > report.md
-          echo '| Module | Version | Size (KB) |' >> report.md
-          echo '| --- | --- | --- |' >> report.md
-          artifact_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          for artifact in $(cat target/powertools-parent-*.buildinfo | grep 'outputs.*.jar' | grep -v 'sources.jar'); do
-            artifact_name=$(echo "$artifact" | cut -d '=' -f2)
-            artifact_name=${artifact_name%-$artifact_version.jar}
-            artifact_size=$(grep "${artifact%%.filename*}.length" target/powertools-parent-*.buildinfo | cut -d '=' -f2)
-            printf "| %s | %s | %.2f |\n" "$artifact_name" "$artifact_version" "$(bc <<< "scale=2; $artifact_size/1000")" >> report.md
-          done
-      - name: Find potential existing report
-        if: ${{ matrix.java == '11.0.x' }} # do it once
-        uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1 # 2.4.0
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: Artifacts Size Report
-      - name: Write artifacts size report in comment
-        if: ${{ matrix.java == '11.0.x' }} # do it once
-        uses: peter-evans/create-or-update-comment@c6c9a1a66007646a28c153e2a8580a5bad27bcfa # 3.0.2
-        with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body-path: 'report.md'
-          edit-mode: replace
   savepr:
     runs-on: ubuntu-latest
     name: Save PR number if running on PR by dependabot

--- a/pom.xml
+++ b/pom.xml
@@ -369,6 +369,14 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-artifact-plugin</artifactId>
+                <version>3.4.1</version>
+                <configuration>
+                    <reproducible>true</reproducible>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>dev.aspectj</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <version>${aspectj-maven-plugin.version}</version>


### PR DESCRIPTION
**Issue #, if available:** #1102 

## Description of changes:

Display a report in GitHub comments about jars size. (Ideally would be great to have the history and see if it's growing)

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
