### PR TITLE
Fix Dependabot configuration to ignore latest version of Mockito

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,5 @@ updates:
       - "dependencies"
     ignore:
       # Ignore Mockito 5.X.X as it does not support Java 8
-      - dependency-name: mockito-*
+      - dependency-name: "org.mockito:mockito-*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION


## Description of changes:

Reason: Mockito 5 requires Java 11.  Issue with incorrect name found after the migration. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
