### PR TITLE
fix: e2e tests on JDK8

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -45,4 +45,4 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_TO_ASSUME }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Run e2e test with Maven
-        run: mvn -Pe2e -B verify --file powertools-e2e-tests/pom.xml
+        run: mvn -Pbuild-without-spotbugs -DskipTests install --file pom.xml && mvn -Pe2e -B verify --file powertools-e2e-tests/pom.xml

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [main, fix-e2e-tests]
+    branches: [main]
     paths: # add other modules when there are under e2e tests
       - 'powertools-e2e-tests/**'
       - 'powertools-core/**'

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [main]
+    branches: [main, fix-e2e-tests]
     paths: # add other modules when there are under e2e tests
       - 'powertools-e2e-tests/**'
       - 'powertools-core/**'

--- a/powertools-e2e-tests/handlers/parameters/pom.xml
+++ b/powertools-e2e-tests/handlers/parameters/pom.xml
@@ -31,7 +31,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>dev.aspectj</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <configuration>
                     <source>${maven.compiler.source}</source>

--- a/powertools-e2e-tests/handlers/parameters/src/main/java/software/amazon/lambda/powertools/e2e/Function.java
+++ b/powertools-e2e-tests/handlers/parameters/src/main/java/software/amazon/lambda/powertools/e2e/Function.java
@@ -2,16 +2,11 @@ package software.amazon.lambda.powertools.e2e;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import software.amazon.lambda.powertools.logging.Logging;
-import software.amazon.lambda.powertools.parameters.ParamManager;
-import software.amazon.lambda.powertools.parameters.cache.CacheManager;
 import software.amazon.lambda.powertools.parameters.AppConfigProvider;
+import software.amazon.lambda.powertools.parameters.ParamManager;
 
 public class Function implements RequestHandler<Input, String> {
-
-    private static final Logger LOG = LogManager.getLogger(Function.class);
 
     @Logging
     public String handleRequest(Input input, Context context) {

--- a/powertools-e2e-tests/handlers/pom.xml
+++ b/powertools-e2e-tests/handlers/pom.xml
@@ -12,14 +12,14 @@
     <properties>
         <lambda.powertools.version>1.15.0</lambda.powertools.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
 
         <lambda.java.core>1.2.2</lambda.java.core>
-        <lambda.java.events>3.11.0</lambda.java.events>
-        <maven.shade.version>3.2.4</maven.shade.version>
-        <aspectj.version>1.13.1</aspectj.version>
-        <maven.compiler.version>3.10.1</maven.compiler.version>
+        <lambda.java.events>3.11.2</lambda.java.events>
+        <maven.shade.version>3.5.0</maven.shade.version>
+        <aspectj.plugin.version>1.13.1</aspectj.plugin.version>
+        <maven.compiler.version>3.11.0</maven.compiler.version>
     </properties>
 
     <modules>
@@ -105,21 +105,106 @@
                     </dependencies>
                 </plugin>
                 <plugin>
-                    <groupId>dev.aspectj</groupId>
-                    <artifactId>aspectj-maven-plugin</artifactId>
-                    <version>1.13.1</version>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven.compiler.version}</version>
                     <configuration>
                         <source>${maven.compiler.source}</source>
                         <target>${maven.compiler.target}</target>
+                        <useIncrementalCompilation>false</useIncrementalCompilation>
                     </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <profile>
+            <id>jdk8</id>
+            <activation>
+                <jdk>(,11)</jdk> <!-- < 11 -->
+            </activation>
+            <properties>
+                <aspectj.version>1.9.7</aspectj.version>
+            </properties>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.aspectj</groupId>
+                        <artifactId>aspectjtools</artifactId>
+                        <version>${aspectj.version}</version>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>dev.aspectj</groupId>
+                            <artifactId>aspectj-maven-plugin</artifactId>
+                            <version>${aspectj.plugin.version}</version>
+                            <configuration>
+                                <source>${maven.compiler.source}</source>
+                                <target>${maven.compiler.target}</target>
+                                <complianceLevel>${maven.compiler.target}</complianceLevel>
+                                <Xlint>ignore</Xlint>
+                                <encoding>${project.build.sourceEncoding}</encoding>
+                            </configuration>
+                            <executions>
+                                <execution>
+                                    <phase>process-sources</phase>
+                                    <goals>
+                                        <goal>compile</goal>
+                                        <goal>test-compile</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                            <!-- Enforce aspectJ 1.9.7 -->
+                            <dependencies>
+                                <dependency>
+                                    <groupId>org.aspectj</groupId>
+                                    <artifactId>aspectjtools</artifactId>
+                                    <version>${aspectj.version}</version>
+                                </dependency>
+                            </dependencies>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>jdk11plus</id>
+            <activation>
+                <jdk>[11,)</jdk> <!-- >= 11 -->
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>dev.aspectj</groupId>
+                            <artifactId>aspectj-maven-plugin</artifactId>
+                            <version>${aspectj.plugin.version}</version>
+                            <configuration>
+                                <source>${maven.compiler.source}</source>
+                                <target>${maven.compiler.target}</target>
+                                <complianceLevel>${maven.compiler.target}</complianceLevel>
+                                <Xlint>ignore</Xlint>
+                                <encoding>${project.build.sourceEncoding}</encoding>
+                            </configuration>
+                            <executions>
+                                <execution>
+                                    <phase>process-sources</phase>
+                                    <goals>
+                                        <goal>compile</goal>
+                                        <goal>test-compile</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/powertools-e2e-tests/pom.xml
+++ b/powertools-e2e-tests/pom.xml
@@ -14,9 +14,8 @@
     <description>Powertools for AWS Lambda (Java)End-To-End Tests</description>
 
     <properties>
-        <!-- we can use Java 11 for integration tests, not forced to stick to Java 8 -->
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <constructs.version>10.2.55</constructs.version>
         <cdk.version>2.84.0</cdk.version>
 

--- a/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/ParametersE2ET.java
+++ b/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/ParametersE2ET.java
@@ -7,6 +7,7 @@ import software.amazon.lambda.powertools.testutils.lambda.InvocationResult;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -21,10 +22,11 @@ public class ParametersE2ET {
     private final AppConfig appConfig;
 
     public ParametersE2ET() {
+        String appName = UUID.randomUUID().toString();
         Map<String,String> params = new HashMap<>();
         params.put("key1", "value1");
         params.put("key2", "value2");
-        appConfig = new AppConfig("e2eApp", "e2etest", params);
+        appConfig = new AppConfig(appName, "e2etest", params);
     }
     @BeforeAll
     @Timeout(value = 5, unit = TimeUnit.MINUTES)

--- a/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/ParametersE2ET.java
+++ b/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/ParametersE2ET.java
@@ -1,6 +1,5 @@
 package software.amazon.lambda.powertools;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
 import software.amazon.lambda.powertools.testutils.AppConfig;
 import software.amazon.lambda.powertools.testutils.Infrastructure;
@@ -17,10 +16,6 @@ import static software.amazon.lambda.powertools.testutils.lambda.LambdaInvoker.i
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ParametersE2ET {
-
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
     private Infrastructure infrastructure;
     private String functionName;
     private final AppConfig appConfig;


### PR DESCRIPTION
**Issue #, if available:**

Fix end to end tests for Java8. Error due to aspectJ version 

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
