### PR TITLE
fix: E2E tests - Use GUID for application name

### DIFF
--- a/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/ParametersE2ET.java
+++ b/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/ParametersE2ET.java
@@ -8,6 +8,7 @@ import software.amazon.lambda.powertools.testutils.lambda.InvocationResult;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -26,10 +27,11 @@ public class ParametersE2ET {
     private final AppConfig appConfig;
 
     public ParametersE2ET() {
+        String appName = UUID.randomUUID().toString();
         Map<String,String> params = new HashMap<>();
         params.put("key1", "value1");
         params.put("key2", "value2");
-        appConfig = new AppConfig("e2eApp", "e2etest", params);
+        appConfig = new AppConfig(appName, "e2etest", params);
     }
     @BeforeAll
     @Timeout(value = 5, unit = TimeUnit.MINUTES)


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:
The AppConfig application ID used in the E2E tests is static, which breaks on the CI server as we run the tests in parallel for multiple languages at once. This change introduces a GUID for app name instead.
 
<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
