### PR TITLE
fix: ParamManager cannot provide default SSM & Secrets providers

### DIFF
--- a/powertools-parameters/pom.xml
+++ b/powertools-parameters/pom.xml
@@ -133,4 +133,18 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <environmentVariables>
+                        <AWS_REGION>eu-central-1</AWS_REGION>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/powertools-parameters/src/main/java/software/amazon/lambda/powertools/parameters/ParamManager.java
+++ b/powertools-parameters/src/main/java/software/amazon/lambda/powertools/parameters/ParamManager.java
@@ -171,7 +171,7 @@ public final class ParamManager {
    static <T extends BaseProvider> T createProvider(Class<T> providerClass) {
         try {
             Constructor<T> constructor = providerClass.getDeclaredConstructor(CacheManager.class);
-            T provider = constructor.newInstance(cacheManager); // FIXME: avoid reflection here as we may have issues (#
+            T provider = constructor.newInstance(cacheManager); // FIXME: avoid reflection here as we may have issues (#1280)
             provider.setTransformationManager(transformationManager);
             return provider;
         } catch (ReflectiveOperationException e) {

--- a/powertools-parameters/src/test/java/software/amazon/lambda/powertools/parameters/ParamManagerTest.java
+++ b/powertools-parameters/src/test/java/software/amazon/lambda/powertools/parameters/ParamManagerTest.java
@@ -18,6 +18,7 @@ import software.amazon.lambda.powertools.parameters.cache.CacheManager;
 import software.amazon.lambda.powertools.parameters.internal.CustomProvider;
 import software.amazon.lambda.powertools.parameters.transform.TransformationManager;
 
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatRuntimeException;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -79,23 +80,38 @@ public class ParamManagerTest {
     }
 
     @Test
-    public void testGetSecretsProvider() {
+    public void testGetSecretsProvider_withoutParameter_shouldCreateDefaultClient() {
 
         // Act
         SecretsProvider secretsProvider = ParamManager.getSecretsProvider();
 
         // Assert
         assertNotNull(secretsProvider);
+        assertNotNull(secretsProvider.getClient());
     }
 
     @Test
-    public void testGetSSMProvider() {
+    public void testGetSSMProvider_withoutParameter_shouldCreateDefaultClient() {
 
         // Act
         SSMProvider ssmProvider = ParamManager.getSsmProvider();
 
         // Assert
         assertNotNull(ssmProvider);
+        assertNotNull(ssmProvider.getClient());
     }
 
+    @Test
+    public void testGetDynamoDBProvider_requireOtherParameters_throwException() {
+
+        // Act & Assert
+        assertThatIllegalArgumentException().isThrownBy(() -> ParamManager.getProvider(DynamoDbProvider.class));
+    }
+
+    @Test
+    public void testGetAppConfigProvider_requireOtherParameters_throwException() {
+
+        // Act & Assert
+        assertThatIllegalArgumentException().isThrownBy(() -> ParamManager.getProvider(AppConfigProvider.class));
+    }
 }


### PR DESCRIPTION
**Issue #, if available:** #1280

## Description of changes:

- It was partially fixed in https://github.com/aws-powertools/powertools-lambda-java/commit/c7aedc4d2a61013450bf472bb7a8285f8cf80e41 with the addition of constructors with no client in parameter
- Completed the fix, adding the creation of the Client
- Deprecated the generic method to get Providers by passing a class (will be removed in V2)

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
