### PR TITLE
chore: Make request for Logger explicitly for current class

### DIFF
--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -239,7 +239,7 @@ to customise what is logged.
      */
     public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
     
-        Logger log = LogManager.getLogger();
+        Logger log = LogManager.getLogger(App.class);
     
         @Logging
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent input, final Context context) {
@@ -256,7 +256,7 @@ to customise what is logged.
      */
     public class AppLogEvent implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
     
-        Logger log = LogManager.getLogger();
+        Logger log = LogManager.getLogger(AppLogEvent.class);
         
         @Logging(logEvent = true)
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent input, final Context context) {
@@ -315,7 +315,7 @@ You can set a Correlation ID using `correlationIdPath` attribute by passing a [J
      */
     public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
     
-        Logger log = LogManager.getLogger();
+        Logger log = LogManager.getLogger(App.class);
     
         @Logging(correlationIdPath = "/headers/my_request_id_header")
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent input, final Context context) {
@@ -364,7 +364,7 @@ for known event sources, where either a request ID or X-Ray Trace ID are present
      */
     public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
     
-        Logger log = LogManager.getLogger();
+        Logger log = LogManager.getLogger(App.class);
     
         @Logging(correlationIdPath = CorrelationIdPathConstants.API_GATEWAY_REST)
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent input, final Context context) {
@@ -417,7 +417,7 @@ You can append your own keys to your existing logs via `appendKey`.
      */
     public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
     
-        Logger log = LogManager.getLogger();
+        Logger log = LogManager.getLogger(App.class);
     
         @Logging(logEvent = true)
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent input, final Context context) {
@@ -449,7 +449,7 @@ You can remove any additional key from entry using `LoggingUtils.removeKeys()`.
      */
     public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
     
-        Logger log = LogManager.getLogger();
+        Logger log = LogManager.getLogger(App.class);
     
         @Logging(logEvent = true)
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent input, final Context context) {
@@ -484,7 +484,7 @@ this means that custom keys can be persisted across invocations. If you want all
      */
     public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
     
-        Logger log = LogManager.getLogger();
+        Logger log = LogManager.getLogger(App.class);
     
         @Logging(clearState = true)
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent input, final Context context) {
@@ -545,7 +545,7 @@ specific fields from received event due to security.
      */
     public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
     
-        Logger log = LogManager.getLogger();
+        Logger log = LogManager.getLogger(App.class);
 
         static {
             ObjectMapper objectMapper = new ObjectMapper();
@@ -575,7 +575,7 @@ via `samplingRate` attribute on annotation.
      */
     public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
     
-        Logger log = LogManager.getLogger();
+        Logger log = LogManager.getLogger(App.class);
     
         @Logging(samplingRate = 0.5)
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent input, final Context context) {

--- a/examples/powertools-examples-parameters/src/main/java/org/demo/parameters/ParametersFunction.java
+++ b/examples/powertools-examples-parameters/src/main/java/org/demo/parameters/ParametersFunction.java
@@ -23,7 +23,7 @@ import static software.amazon.lambda.powertools.parameters.transform.Transformer
 import static software.amazon.lambda.powertools.parameters.transform.Transformer.json;
 
 public class ParametersFunction implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
-    private final static Logger log = LogManager.getLogger();
+    private final static Logger log = LogManager.getLogger(ParametersFunction.class);
 
     SSMProvider ssmProvider = ParamManager.getSsmProvider();
     SecretsProvider secretsProvider = ParamManager.getSecretsProvider();

--- a/powertools-idempotency/src/test/java/software/amazon/lambda/powertools/idempotency/handlers/IdempotencyFunction.java
+++ b/powertools-idempotency/src/test/java/software/amazon/lambda/powertools/idempotency/handlers/IdempotencyFunction.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class IdempotencyFunction implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
-    private final static Logger LOG = LogManager.getLogger();
+    private final static Logger LOG = LogManager.getLogger(IdempotencyFunction.class);
 
     public boolean handlerExecuted = false;
 


### PR DESCRIPTION
**Issue #, if available:** #825

## Description of changes:

In this change the documentation has been updated to explicitly state the class for which a logger needs to be retrieved.
Also changed two function handler classes to follow this best practice. 

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
