### PR TITLE
docs: Add discord + sec disclosure links to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,15 @@ The following companies, among others, use Powertools:
 * [MkDocs](https://www.mkdocs.org/)
 * [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/)
 
+## Connect
+
+* **Powertools for AWS Lambda on Discord**: `#java` - **[Invite link](https://discord.gg/B8zZKbbyET)**
+* **Email**: <aws-lambda-powertools-feedback@amazon.com>
+
+## Security disclosures
+
+If you think you’ve found a potential security issue, please do not post it in the Issues.  Instead, please follow the instructions [here](https://aws.amazon.com/security/vulnerability-reporting/) or [email AWS security directly](mailto:aws-security@amazon.com).
+
 ## License
 
 This library is licensed under the Apache License, Version 2.0. See the LICENSE file.


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:
Lining our README contents up with the other powertools languages and providing a link to discord. 

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
