### PR TITLE
chore: Add 'v2' branch to build workflows

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - v2
     paths:
       - 'docs/**'
       - 'mkdocs.yml'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - v2
     paths:
       - 'powertools-cloudformation/**'
       - 'powertools-core/**'

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -4,7 +4,9 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [main]
+    branches:
+      - main
+      - v2
     paths: # add other modules when there are under e2e tests
       - 'powertools-e2e-tests/**'
       - 'powertools-core/**'

--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - v2
     paths:
       - 'powertools-cloudformation/**'
       - 'powertools-core/**'


### PR DESCRIPTION
**Issue #, if available:**
#1337 

## Description of changes:
The v2 branch should build as part of the various build workflows, so that when we PR into it, we can treat it like another 'main'.

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
