### PR TITLE
docs: Add additional workflow for rebuilding old versions of documentation

### DIFF
--- a/.github/workflows/rebuild-old-docs.yml
+++ b/.github/workflows/rebuild-old-docs.yml
@@ -1,0 +1,100 @@
+name: Rebuild old docs
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        default: "1.3.0"
+        required: true
+      hash:
+        default: "8ee1896a4d31d8789a490e4befeade1ee02ee1fc"
+        required: true
+      alias:
+        description: "Alias to associate version (latest, stage)"
+        required: true
+        default: "latest"
+        type: string
+
+permissions:
+  contents: write
+  id-token: write
+  pages: write
+
+
+jobs:
+  publish-docs:
+    runs-on: ubuntu-latest
+    environment: Docs
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
+        with:
+          # While `fetch-depth` is used to allow the workflow to later commit & push the changes.
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b # v4.6.0
+        with:
+          python-version: "3.8"
+      - name: Install doc generation dependencies
+        run: |
+          pip install --upgrade pip 
+          pip install -r docs/requirements.txt
+      - name: Setup doc deploy
+        run: |
+          git config --global user.name Docs deploy
+          git config --global user.email aws-devax-open-source@amazon.com
+      - name: Normalize Version Number
+        run: echo "VERSION=$(echo ${{ inputs.version }} | sed 's/v//')" >> $GITHUB_ENV
+
+      - name: Build docs website and API reference
+        run: |
+          rm -rf site
+          python release-old-docs.py ${{ inputs.version }} ${{ inputs.hash }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_DOCS_ROLE_ARN }}
+      - name: Deploy Docs (Version)
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          aws s3 sync \
+            site/ \
+            s3://${{ secrets.AWS_DOCS_BUCKET }}/lambda-java/${{ env.VERSION }}/
+      - name: Deploy Docs (Alias)
+        env:
+          VERSION: ${{ inputs.version }}
+          ALIAS: ${{ inputs.alias }}
+        run: |
+          aws s3 sync \
+            site/ \
+            s3://${{ secrets.AWS_DOCS_BUCKET }}/lambda-java/${{ env.ALIAS }}/
+      - name: Deploy Docs (Version JSON)
+        env:
+          VERSION: ${{ inputs.version }}
+          ALIAS: ${{ inputs.alias }}
+
+
+        # We originally used "mike" from PyPi to manage versions for us, but since we moved to S3, we can't use it to manage versions any more.
+        # Instead, we're using some shell script that manages the versions.
+        #
+        # Operations:
+        #   1. Download the versions.json file from S3
+        #   2. Find any reference to the alias and delete it from the versions file
+        #   3. This is voodoo (don't use JQ):
+        #      - we assign the input as $o and the new version/alias as $n,
+        #      - we check if the version number exists in the file already (for republishing docs)
+        #      - if it's an alias (stage/latest/*) or old version, we do nothing and output $o (original input)
+        #      - if it's a new version number, we add it at position 0 in the array.
+        #   4. Once done, we'll upload it back to S3.
+
+        run: |
+          aws s3 cp \
+            s3://${{ secrets.AWS_DOCS_BUCKET }}/lambda-java/versions.json \
+            versions_old.json
+          jq 'del(.[].aliases[] | select(. == "${{ env.ALIAS }}"))' < versions_old.json > versions_proc.json
+          jq '. as $o | [{"title": "${{ env.VERSION }}", "version": "${{ env.VERSION }}", "aliases": ["${{env.ALIAS}}"] }] as $n | $n | if .[0].title | test("[a-z]+") or any($o[].title == "${{ env.VERSION }}";.) then $o else $n + $o end' < versions_proc.json > versions.json
+          aws s3 cp \
+            versions.json \
+            s3://${{ secrets.AWS_DOCS_BUCKET }}/lambda-java/versions.json

--- a/release-old-docs.py
+++ b/release-old-docs.py
@@ -1,0 +1,34 @@
+import subprocess
+import sys
+
+if __name__ == '__main__':
+
+    version = sys.argv[1]
+    hash = sys.argv[2]
+
+
+    print(version)
+    print(hash)
+
+    git_checkout = f"git checkout -f {hash}"
+    mike_deploy = f"mike deploy --update-aliases {version} latest"
+
+    message = subprocess.check_output(git_checkout, shell=True, universal_newlines=True)
+    print(message)
+
+    with open('mkdocs.yml', 'r') as file :
+      filedata = file.read()
+
+    # Replace the target string
+
+    if "extra:" in filedata:
+        filedata = filedata.replace('extra:', 'extra:\n  version:\n    provider: mike\n    default: latest')
+    else:
+        filedata = filedata + "\n\nextra:\n  version:\n    provider: mike\n    default: latest"
+
+    # Write the file out again
+    with open('mkdocs.yml', 'w') as file:
+      file.write(filedata)
+
+    message = subprocess.check_output(mike_deploy, shell=True, universal_newlines=True)
+    print(message)


### PR DESCRIPTION
**Issue #, if available:**

#1239

This change is required only for rebuilding old documentation and publish it to S3. Should be reverted when job is done.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
