### PR TITLE
docs: Change link to absolute versioned path for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Next, configure the aspectj-maven-plugin to compile-time weave (CTW) the aws-lam
 
 ## Examples
 
-See the **[examples](examples)**  directory for example projects showcasing usage of different utilities.
+See the latest release of the **[examples](https://github.com/aws-powertools/powertools-lambda-java/tree/v1.16.1/examples)** for example projects showcasing usage of different utilities.
 
 Have a demo project to contribute which showcase usage of different utilities from powertools? We are happy to accept it [here](CONTRIBUTING.md#security-issue-notifications).
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Next, configure the aspectj-maven-plugin to compile-time weave (CTW) the aws-lam
 
 ## Examples
 
-See the latest release of the **[examples](https://github.com/aws-powertools/powertools-lambda-java/tree/v1.16.1/examples)** for example projects showcasing usage of different utilities.
+See the latest release of the **[examples](https://github.com/aws-powertools/powertools-lambda-java/tree/v1.17.0/examples)** for example projects showcasing usage of different utilities.
 
 Have a demo project to contribute which showcase usage of different utilities from powertools? We are happy to accept it [here](CONTRIBUTING.md#security-issue-notifications).
 


### PR DESCRIPTION
**Issue #, if available:**
#1336 

## Description of changes:
Update the link to the examples to point at the latest tagged release. The release prep process will move this to the next tag version whenever we deploy a new release.

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
