### PR TITLE
fix: Don't deploy the CDK

### DIFF
--- a/examples/powertools-examples-core/cdk/infra/pom.xml
+++ b/examples/powertools-examples-core/cdk/infra/pom.xml
@@ -10,6 +10,7 @@
         <cdk.version>2.91.0</cdk.version>
         <constructs.version>[10.0.0,11.0.0)</constructs.version>
         <junit.version>5.10.0</junit.version>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
     <build>
         <plugins>


### PR DESCRIPTION
**Issue #, if available:** n/a

The new CDK example infrastructure needs to be blocked from the maven artifact publishing.

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
