### PR TITLE
docs(logging): correct log example keys 

### DIFF
--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -347,7 +347,7 @@ You can set a Correlation ID using `correlationIdPath` attribute by passing a [J
 	  	"functionName": "test",
 	  	"functionMemorySize": 128,
 	  	"functionArn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
-	  	"lambda_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
+	  	"function_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
 	  	"correlation_id": "correlation_id_value"
 	}
     ```
@@ -397,7 +397,7 @@ for known event sources, where either a request ID or X-Ray Trace ID are present
 	  	"functionName": "test",
 	  	"functionMemorySize": 128,
 	  	"functionArn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
-	  	"lambda_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
+	  	"function_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
 	  	"correlation_id": "correlation_id_value"
 	}
     ```
@@ -510,7 +510,7 @@ this means that custom keys can be persisted across invocations. If you want all
 	  	"functionName": "test",
 	  	"functionMemorySize": 128,
 	  	"functionArn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
-	  	"lambda_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
+	  	"function_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72",
         "specialKey": "value"
 	}
     ```
@@ -527,7 +527,7 @@ this means that custom keys can be persisted across invocations. If you want all
 	  	"functionName": "test",
 	  	"functionMemorySize": 128,
 	  	"functionArn": "arn:aws:lambda:eu-west-1:12345678910:function:test",
-	  	"lambda_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72"
+	  	"function_request_id": "52fdfc07-2182-154f-163f-5f0f9a621d72"
 	}
     ```
 


### PR DESCRIPTION

**Issue #, if available:**

## Description of changes:

Correct logging JSON example shown near bottom of docs.  Still shows `lambda_request_id` - see online [here](https://docs.powertools.aws.dev/lambda/java/core/logging/#setting-a-correlation-id).

This PR updates this example (and others) to `function_request_id`, which aligns with the implementation [here](https://github.com/aws-powertools/powertools-lambda-java/blob/c6932aeb0d0d5689f1c8a5d0f3897c8c69850c3b/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/internal/DefaultLambdaFields.java#L26)


**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [x] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
