### PR TITLE
docs: apply line highlight only for default light mode

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -3,7 +3,9 @@
 }
 
 .highlight .hll {
-    background-color: lavender
+    [data-md-color-scheme="default"] {
+        background-color: lavender;
+    }
 }
 
 .md-typeset table:not([class]) {


### PR DESCRIPTION
**Issue #, if available:** #1452

## Description of changes:

This PR fixes the hard to read line highlight in dark mode. We had similar issue in [TypeScript before ](https://github.com/aws-powertools/powertools-lambda-typescript/pull/1695/files) and thanks to @shdq he noticed the same problem in Java docs. 

Before: 

<img width="675" alt="Screenshot 2023-10-02 at 09 48 16" src="https://github.com/aws-powertools/powertools-lambda-java/assets/2674178/c0fc85f6-fa19-494b-9c1d-b278df472060">

After: 

<img width="627" alt="Screenshot 2023-10-02 at 10 03 28" src="https://github.com/aws-powertools/powertools-lambda-java/assets/2674178/1eb13be6-9a81-48cc-9877-ff88ea5f3633">



<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
