### PR TITLE
fix: enforce jackson databind version

### DIFF
--- a/powertools-serialization/pom.xml
+++ b/powertools-serialization/pom.xml
@@ -67,6 +67,10 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j2-impl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>


### PR DESCRIPTION
**Issue #, if available:** #1471

## Description of changes:

Enforcing our version of jackson databind to avoid the transitive old one from jmespath

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
