### PR TITLE
fix: get trace id from system property when env var is not set

### DIFF
--- a/powertools-core/src/main/java/software/amazon/lambda/powertools/core/internal/LambdaConstants.java
+++ b/powertools-core/src/main/java/software/amazon/lambda/powertools/core/internal/LambdaConstants.java
@@ -24,6 +24,7 @@ public class LambdaConstants {
     @Deprecated
     public static final String ON_DEMAND = "on-demand";
     public static final String X_AMZN_TRACE_ID = "_X_AMZN_TRACE_ID";
+    public static final String XRAY_TRACE_HEADER = "com.amazonaws.xray.traceHeader";
     public static final String AWS_SAM_LOCAL = "AWS_SAM_LOCAL";
     public static final String ROOT_EQUALS = "Root=";
     public static final String POWERTOOLS_SERVICE_NAME = "POWERTOOLS_SERVICE_NAME";

--- a/powertools-core/src/main/java/software/amazon/lambda/powertools/core/internal/LambdaHandlerProcessor.java
+++ b/powertools-core/src/main/java/software/amazon/lambda/powertools/core/internal/LambdaHandlerProcessor.java
@@ -95,7 +95,7 @@ public final class LambdaHandlerProcessor {
 
     public static Optional<String> getXrayTraceId() {
         String X_AMZN_TRACE_ID = getenv(LambdaConstants.X_AMZN_TRACE_ID);
-        // For the Java Lambda 17+, the Trace ID is set as a System Property
+        // For the Java Lambda 17+ runtime, the Trace ID is set as a System Property
         if (X_AMZN_TRACE_ID == null) {
             X_AMZN_TRACE_ID = getProperty(LambdaConstants.XRAY_TRACE_HEADER);
         }

--- a/powertools-core/src/main/java/software/amazon/lambda/powertools/core/internal/LambdaHandlerProcessor.java
+++ b/powertools-core/src/main/java/software/amazon/lambda/powertools/core/internal/LambdaHandlerProcessor.java
@@ -16,6 +16,7 @@ package software.amazon.lambda.powertools.core.internal;
 
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
+import static software.amazon.lambda.powertools.core.internal.SystemWrapper.getProperty;
 import static software.amazon.lambda.powertools.core.internal.SystemWrapper.getenv;
 
 import com.amazonaws.services.lambda.runtime.Context;
@@ -93,7 +94,12 @@ public final class LambdaHandlerProcessor {
     }
 
     public static Optional<String> getXrayTraceId() {
-        final String X_AMZN_TRACE_ID = getenv(LambdaConstants.X_AMZN_TRACE_ID);
+        String X_AMZN_TRACE_ID = getenv(LambdaConstants.X_AMZN_TRACE_ID);
+        // For the Java Lambda 17+, the Trace ID is set as a System Property
+        if (X_AMZN_TRACE_ID == null) {
+            X_AMZN_TRACE_ID = getProperty(LambdaConstants.XRAY_TRACE_HEADER);
+        }
+
         if (X_AMZN_TRACE_ID != null) {
             return of(X_AMZN_TRACE_ID.split(";")[0].replace(LambdaConstants.ROOT_EQUALS, ""));
         }

--- a/powertools-core/src/main/java/software/amazon/lambda/powertools/core/internal/SystemWrapper.java
+++ b/powertools-core/src/main/java/software/amazon/lambda/powertools/core/internal/SystemWrapper.java
@@ -21,4 +21,8 @@ public class SystemWrapper {
     public static String getenv(String name) {
         return System.getenv(name);
     }
+
+    public static String getProperty(String name) {
+        return System.getProperty(name);
+    }
 }

--- a/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/LoggingE2ET.java
+++ b/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/LoggingE2ET.java
@@ -46,6 +46,7 @@ public class LoggingE2ET {
     public static void setup() {
         infrastructure = Infrastructure.builder()
                 .testName(LoggingE2ET.class.getSimpleName())
+                .tracing(true)
                 .pathToFunction("logging")
                 .environmentVariables(
                         Stream.of(new String[][] {
@@ -83,6 +84,7 @@ public class LoggingE2ET {
         assertThat(jsonNode.get("message").asText()).isEqualTo("New Order");
         assertThat(jsonNode.get("orderId").asText()).isEqualTo(orderId);
         assertThat(jsonNode.get("coldStart").asBoolean()).isTrue();
+        assertThat(jsonNode.get("xray_trace_id").asText()).isNotBlank();
         assertThat(jsonNode.get("function_request_id").asText()).isEqualTo(invocationResult1.getRequestId());
 
         // second call should not be cold start

--- a/powertools-logging/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspectTest.java
+++ b/powertools-logging/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspectTest.java
@@ -270,7 +270,7 @@ class LambdaLoggingAspectTest {
 
         try (MockedStatic<SystemWrapper> mocked = mockStatic(SystemWrapper.class)) {
             mocked.when(() -> getenv("_X_AMZN_TRACE_ID"))
-                    .thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1\"");
+                    .thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1");
 
             requestHandler.handleRequest(new Object(), context);
 

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/MetricsLoggerTest.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/MetricsLoggerTest.java
@@ -18,6 +18,7 @@ import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.mockito.Mockito.mockStatic;
+import static software.amazon.lambda.powertools.core.internal.SystemWrapper.getProperty;
 import static software.amazon.lambda.powertools.core.internal.SystemWrapper.getenv;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -163,6 +164,41 @@ class MetricsLoggerTest {
         assertThatNullPointerException()
                 .isThrownBy(() -> MetricsUtils.defaultDimensionSet(null))
                 .withMessage("Null dimension set not allowed");
+    }
+
+    @Test
+    void shouldUseTraceIdFromSystemPropertyIfEnvVarNotPresent() {
+        try (MockedStatic<SystemWrapper> mocked = mockStatic(SystemWrapper.class);
+             MockedStatic<software.amazon.lambda.powertools.core.internal.SystemWrapper> internalWrapper = mockStatic(
+                     software.amazon.lambda.powertools.core.internal.SystemWrapper.class)) {
+            mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
+            mocked.when(() -> SystemWrapper.getenv("POWERTOOLS_METRICS_NAMESPACE")).thenReturn("GlobalName");
+            internalWrapper.when(() -> getenv("_X_AMZN_TRACE_ID"))
+                    .thenReturn(null);
+            internalWrapper.when(() -> getProperty("com.amazonaws.xray.traceHeader"))
+                    .thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1");
+
+            MetricsUtils.withSingleMetric("Metric1", 1, Unit.COUNT,
+                    metricsLogger -> metricsLogger.setDimensions(DimensionSet.of("Dimension1", "Value1")));
+
+            assertThat(out.toString())
+                    .satisfies(s ->
+                    {
+                        Map<String, Object> logAsJson = readAsJson(s);
+
+                        assertThat(logAsJson)
+                                .containsEntry("Metric1", 1.0)
+                                .containsEntry("Dimension1", "Value1")
+                                .containsKey("_aws")
+                                .containsEntry("xray_trace_id", "1-5759e988-bd862e3fe1be46a994272793");
+
+                        Map<String, Object> aws = (Map<String, Object>) logAsJson.get("_aws");
+
+                        assertThat(aws.get("CloudWatchMetrics"))
+                                .asString()
+                                .contains("Namespace=GlobalName");
+                    });
+        }
     }
 
     private void testLogger(Consumer<Consumer<MetricsLogger>> methodToTest) {

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/MetricsLoggerTest.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/MetricsLoggerTest.java
@@ -67,7 +67,7 @@ class MetricsLoggerTest {
                      software.amazon.lambda.powertools.core.internal.SystemWrapper.class)) {
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
             internalWrapper.when(() -> getenv("_X_AMZN_TRACE_ID"))
-                    .thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1\"");
+                    .thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1");
 
             MetricsUtils.defaultDimensions(DimensionSet.of("Service", "Booking"));
 
@@ -97,7 +97,7 @@ class MetricsLoggerTest {
                      software.amazon.lambda.powertools.core.internal.SystemWrapper.class)) {
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
             internalWrapper.when(() -> getenv("_X_AMZN_TRACE_ID"))
-                    .thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1\"");
+                    .thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1");
 
             MetricsUtils.withSingleMetric("Metric1", 1, Unit.COUNT, "test",
                     metricsLogger -> metricsLogger.setDimensions(DimensionSet.of("Dimension1", "Value1")));
@@ -124,7 +124,7 @@ class MetricsLoggerTest {
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
             mocked.when(() -> SystemWrapper.getenv("POWERTOOLS_METRICS_NAMESPACE")).thenReturn("GlobalName");
             internalWrapper.when(() -> getenv("_X_AMZN_TRACE_ID"))
-                    .thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1\"");
+                    .thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1");
 
             MetricsUtils.withSingleMetric("Metric1", 1, Unit.COUNT,
                     metricsLogger -> metricsLogger.setDimensions(DimensionSet.of("Dimension1", "Value1")));
@@ -208,7 +208,7 @@ class MetricsLoggerTest {
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
             mocked.when(() -> SystemWrapper.getenv("POWERTOOLS_METRICS_NAMESPACE")).thenReturn("GlobalName");
             internalWrapper.when(() -> getenv("_X_AMZN_TRACE_ID"))
-                    .thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1\"");
+                    .thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1");
 
             methodToTest.accept(metricsLogger ->
             {

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/internal/LambdaMetricsAspectTest.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/internal/LambdaMetricsAspectTest.java
@@ -91,7 +91,7 @@ public class LambdaMetricsAspectTest {
 
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
             internalWrapper.when(() -> getenv("_X_AMZN_TRACE_ID"))
-                    .thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1\"");
+                    .thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1");
 
             MetricsUtils.defaultDimensions(null);
             requestHandler = new PowertoolsMetricsEnabledHandler();
@@ -135,7 +135,7 @@ public class LambdaMetricsAspectTest {
 
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
             internalWrapper.when(() -> getenv("_X_AMZN_TRACE_ID"))
-                    .thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1\"");
+                    .thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1");
 
             requestHandler = new PowertoolsMetricsEnabledDefaultDimensionHandler();
 
@@ -179,7 +179,7 @@ public class LambdaMetricsAspectTest {
 
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
             internalWrapper.when(() -> getenv("_X_AMZN_TRACE_ID"))
-                    .thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1\"");
+                    .thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1");
 
             requestHandler = new PowertoolsMetricsEnabledDefaultNoDimensionHandler();
 


### PR DESCRIPTION
**Issue #, if available:** https://github.com/aws-powertools/powertools-lambda-java/issues/1501

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->
If the `_X_AMZN_TRACE_ID` env var is not set, check the `com.amazonaws.xray.traceHeader` system property.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
