### PR TITLE
fix: null namespace should fallback to default namespace

### DIFF
--- a/powertools-metrics/src/main/java/software/amazon/lambda/powertools/metrics/MetricsUtils.java
+++ b/powertools-metrics/src/main/java/software/amazon/lambda/powertools/metrics/MetricsUtils.java
@@ -178,8 +178,12 @@ public final class MetricsUtils {
 
     private static String defaultNameSpace() {
         MetricsContext context = MetricsLoggerHelper.metricsContext();
-        return "aws-embedded-metrics".equals(context.getNamespace()) ?
-                SystemWrapper.getenv("POWERTOOLS_METRICS_NAMESPACE") : context.getNamespace();
+        if ("aws-embedded-metrics".equals(context.getNamespace())) {
+            String namespace = SystemWrapper.getenv("POWERTOOLS_METRICS_NAMESPACE");
+            return namespace != null ? namespace : "aws-embedded-metrics";
+        } else {
+            return context.getNamespace();
+        }
     }
 
     private static Optional<String> awsRequestId() {


### PR DESCRIPTION
**Issue #, if available:** #1500

## Description of changes:

- fallback to default `aws-embedded-metrics` when POWERTOOLS_METRICS_NAMESPACE is not defined.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
