### PR TITLE
chore: Addition of Warn Message If Invalid Annotation Key While Tracing #1511

### DIFF
--- a/powertools-tracing/pom.xml
+++ b/powertools-tracing/pom.xml
@@ -48,6 +48,10 @@
         </developer>
     </developers>
 
+    <properties>
+        <logback.version>1.2.11</logback.version>
+    </properties>
+
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
@@ -115,6 +119,13 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/powertools-tracing/pom.xml
+++ b/powertools-tracing/pom.xml
@@ -48,10 +48,6 @@
         </developer>
     </developers>
 
-    <properties>
-        <logback.version>1.2.11</logback.version>
-    </properties>
-
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
@@ -119,13 +115,6 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <build>

--- a/powertools-tracing/src/main/java/software/amazon/lambda/powertools/tracing/TracingUtils.java
+++ b/powertools-tracing/src/main/java/software/amazon/lambda/powertools/tracing/TracingUtils.java
@@ -39,7 +39,7 @@ public final class TracingUtils {
      * @param value the value of the annotation
      */
     public static void putAnnotation(String key, String value) {
-        if (!isValidateAnnotationKey(key)) {
+        if (!isValidAnnotationKey(key)) {
             LOG.warn("Ignoring annotation with unsupported characters in key: {}", key);
             return;
         }
@@ -54,7 +54,7 @@ public final class TracingUtils {
      * @param value the value of the annotation
      */
     public static void putAnnotation(String key, Number value) {
-        if (!isValidateAnnotationKey(key)) {
+        if (!isValidAnnotationKey(key)) {
             LOG.warn("Ignoring annotation with unsupported characters in key: {}", key);
             return;
         }
@@ -68,7 +68,7 @@ public final class TracingUtils {
 
      Annotation keys that are added that are invalid are ignored by x-ray.
      **/
-    private static boolean isValidateAnnotationKey(String key) {
+    private static boolean isValidAnnotationKey(String key) {
         return key.matches("^[a-zA-Z0-9_]+$");
     }
 

--- a/powertools-tracing/src/main/java/software/amazon/lambda/powertools/tracing/TracingUtils.java
+++ b/powertools-tracing/src/main/java/software/amazon/lambda/powertools/tracing/TracingUtils.java
@@ -21,12 +21,15 @@ import com.amazonaws.xray.entities.Entity;
 import com.amazonaws.xray.entities.Subsegment;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A class of helper functions to add additional functionality and ease
  * of use.
  */
 public final class TracingUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(TracingUtils.class);
     private static ObjectMapper objectMapper;
 
     /**
@@ -36,6 +39,7 @@ public final class TracingUtils {
      * @param value the value of the annotation
      */
     public static void putAnnotation(String key, String value) {
+        validateAnnotationKey(key);
         AWSXRay.getCurrentSubsegmentOptional()
                 .ifPresent(segment -> segment.putAnnotation(key, value));
     }
@@ -47,8 +51,15 @@ public final class TracingUtils {
      * @param value the value of the annotation
      */
     public static void putAnnotation(String key, Number value) {
+        validateAnnotationKey(key);
         AWSXRay.getCurrentSubsegmentOptional()
                 .ifPresent(segment -> segment.putAnnotation(key, value));
+    }
+
+    private static void validateAnnotationKey(String key) {
+        if (!key.matches("^[a-zA-Z0-9_]+$")) {
+            LOG.warn("ignoring annotation with unsupported characters in key: {}", key);
+        }
     }
 
     /**

--- a/powertools-tracing/src/main/java/software/amazon/lambda/powertools/tracing/TracingUtils.java
+++ b/powertools-tracing/src/main/java/software/amazon/lambda/powertools/tracing/TracingUtils.java
@@ -39,7 +39,10 @@ public final class TracingUtils {
      * @param value the value of the annotation
      */
     public static void putAnnotation(String key, String value) {
-        validateAnnotationKey(key);
+        if (!isValidateAnnotationKey(key)) {
+            LOG.warn("Ignoring annotation with unsupported characters in key: {}", key);
+            return;
+        }
         AWSXRay.getCurrentSubsegmentOptional()
                 .ifPresent(segment -> segment.putAnnotation(key, value));
     }
@@ -51,15 +54,22 @@ public final class TracingUtils {
      * @param value the value of the annotation
      */
     public static void putAnnotation(String key, Number value) {
-        validateAnnotationKey(key);
+        if (!isValidateAnnotationKey(key)) {
+            LOG.warn("Ignoring annotation with unsupported characters in key: {}", key);
+            return;
+        }
         AWSXRay.getCurrentSubsegmentOptional()
                 .ifPresent(segment -> segment.putAnnotation(key, value));
     }
 
-    private static void validateAnnotationKey(String key) {
-        if (!key.matches("^[a-zA-Z0-9_]+$")) {
-            LOG.warn("ignoring annotation with unsupported characters in key: {}", key);
-        }
+    /**
+     Make sure that the annotation key is valid according to
+     <a href='https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-annotations'>the documentation</a>.
+
+     Annotation keys that are added that are invalid are ignored by x-ray.
+     **/
+    private static boolean isValidateAnnotationKey(String key) {
+        return key.matches("^[a-zA-Z0-9_]+$");
     }
 
     /**

--- a/powertools-tracing/src/test/java/software/amazon/lambda/powertools/tracing/TracingUtilsTest.java
+++ b/powertools-tracing/src/test/java/software/amazon/lambda/powertools/tracing/TracingUtilsTest.java
@@ -168,7 +168,7 @@ class TracingUtilsTest {
 
         List<ILoggingEvent> logsList = listAppender.list;
         assertThat(logsList.get(0).getLevel()).isEqualTo(Level.WARN);
-        assertThat(logsList.get(0).getMessage()).isEqualTo("ignoring annotation with unsupported characters in key: {}",inputKey);
+        assertThat(logsList.get(0).getMessage()).isEqualTo("Ignoring annotation with unsupported characters in key: {}",inputKey);
     }
 
     @Test

--- a/powertools-tracing/src/test/java/software/amazon/lambda/powertools/tracing/TracingUtilsTest.java
+++ b/powertools-tracing/src/test/java/software/amazon/lambda/powertools/tracing/TracingUtilsTest.java
@@ -20,21 +20,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static software.amazon.lambda.powertools.tracing.TracingUtils.withEntitySubsegment;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.entities.Entity;
-import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
 
 class TracingUtilsTest {
-
     @BeforeEach
     void setUp() {
         AWSXRay.beginSegment("test");
@@ -130,45 +123,21 @@ class TracingUtilsTest {
     }
 
     @Test
-    void shouldEmitNoLogWarnIfValidCharacterInKey() {
+    void shouldNotAddAnnotationIfInvalidCharacterInKey() {
         AWSXRay.beginSubsegment("subSegment");
-        Logger logger = (Logger) LoggerFactory.getLogger(TracingUtils.class);
-
-        // create and start a ListAppender
-        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
-        listAppender.start();
-
-        // add the appender to the logger
-        logger.addAppender(listAppender);
-
-        TracingUtils.putAnnotation("stringKey", "val");
-
-        List<ILoggingEvent> logsList = listAppender.list;
-        assertThat(AWSXRay.getTraceEntity().getAnnotations())
-                .hasSize(1)
-                .contains(
-                        entry("stringKey", "val")
-                );
-        assertThat(logsList.size()).isZero();
+        String inputKey = "stringKey with spaces";
+        TracingUtils.putAnnotation(inputKey, "val");
+        AWSXRay.getCurrentSubsegmentOptional()
+                .ifPresent(segment -> assertThat(segment.getAnnotations()).size().isEqualTo(0));
     }
 
     @Test
-    void shouldEmitLogWarnIfInvalidCharacterInKey() {
+    void shouldAddAnnotationIfValidCharactersInKey() {
         AWSXRay.beginSubsegment("subSegment");
-        Logger logger = (Logger) LoggerFactory.getLogger(TracingUtils.class);
-
-        // create and start a ListAppender
-        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
-        listAppender.start();
-
-        // add the appender to the logger
-        logger.addAppender(listAppender);
-        String inputKey = "stringKey with spaces";
+        String inputKey = "validKey";
         TracingUtils.putAnnotation(inputKey, "val");
-
-        List<ILoggingEvent> logsList = listAppender.list;
-        assertThat(logsList.get(0).getLevel()).isEqualTo(Level.WARN);
-        assertThat(logsList.get(0).getMessage()).isEqualTo("Ignoring annotation with unsupported characters in key: {}",inputKey);
+        AWSXRay.getCurrentSubsegmentOptional()
+                .ifPresent(segment -> assertThat(segment.getAnnotations()).size().isEqualTo(1));
     }
 
     @Test

--- a/powertools-tracing/src/test/java/software/amazon/lambda/powertools/tracing/TracingUtilsTest.java
+++ b/powertools-tracing/src/test/java/software/amazon/lambda/powertools/tracing/TracingUtilsTest.java
@@ -20,12 +20,18 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static software.amazon.lambda.powertools.tracing.TracingUtils.withEntitySubsegment;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.entities.Entity;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 class TracingUtilsTest {
 
@@ -121,6 +127,48 @@ class TracingUtilsTest {
                     assertThat(subsegment.getMetadata())
                             .hasSize(1);
                 });
+    }
+
+    @Test
+    void shouldEmitNoLogWarnIfValidCharacterInKey() {
+        AWSXRay.beginSubsegment("subSegment");
+        Logger logger = (Logger) LoggerFactory.getLogger(TracingUtils.class);
+
+        // create and start a ListAppender
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        listAppender.start();
+
+        // add the appender to the logger
+        logger.addAppender(listAppender);
+
+        TracingUtils.putAnnotation("stringKey", "val");
+
+        List<ILoggingEvent> logsList = listAppender.list;
+        assertThat(AWSXRay.getTraceEntity().getAnnotations())
+                .hasSize(1)
+                .contains(
+                        entry("stringKey", "val")
+                );
+        assertThat(logsList.size()).isZero();
+    }
+
+    @Test
+    void shouldEmitLogWarnIfInvalidCharacterInKey() {
+        AWSXRay.beginSubsegment("subSegment");
+        Logger logger = (Logger) LoggerFactory.getLogger(TracingUtils.class);
+
+        // create and start a ListAppender
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        listAppender.start();
+
+        // add the appender to the logger
+        logger.addAppender(listAppender);
+        String inputKey = "stringKey with spaces";
+        TracingUtils.putAnnotation(inputKey, "val");
+
+        List<ILoggingEvent> logsList = listAppender.list;
+        assertThat(logsList.get(0).getLevel()).isEqualTo(Level.WARN);
+        assertThat(logsList.get(0).getMessage()).isEqualTo("ignoring annotation with unsupported characters in key: {}",inputKey);
     }
 
     @Test


### PR DESCRIPTION
[**Issue #, 1499:**](https://github.com/aws-powertools/powertools-lambda-java/issues/1499)

## Description of changes:

Change to emit warning log message if an invalid key is used while putting an annotation while tracing.  

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
