### PR TITLE
refactor(v2) Use AWS CRT as the default SDK client

### DIFF
--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -879,7 +879,7 @@ When creating the `DynamoDBPersistenceStore`, you can set a custom [`DynamoDbCli
     ```java
     DynamoDbClient.builder()
         .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
-        .httpClient(UrlConnectionHttpClient.builder().build())
+        .httpClient(AwsCrtHttpClient.builder().build())
         .region(Region.of(System.getenv(AWS_REGION_ENV)))
         .build();
     ```
@@ -1073,7 +1073,7 @@ To unit test your function with DynamoDB Local, you can refer to this guide to [
     
             // Initialize DynamoDBClient
             client = DynamoDbClient.builder()
-                    .httpClient(UrlConnectionHttpClient.builder().build())
+                    .httpClient(AwsCrtHttpClient.builder().build())
                     .region(Region.EU_WEST_1)
                     .endpointOverride(URI.create("http://localhost:" + port))
                     .credentialsProvider(StaticCredentialsProvider.create(
@@ -1151,7 +1151,7 @@ To unit test your function with DynamoDB Local, you can refer to this guide to [
       public App() {
         DynamoDbClientBuilder ddbBuilder = DynamoDbClient.builder()
            .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
-           .httpClient(UrlConnectionHttpClient.builder().build());
+           .httpClient(AwsCrtHttpClient.builder().build());
     
         if (System.getenv("AWS_SAM_LOCAL") != null) {
           ddbBuilder.endpointOverride(URI.create("http://dynamo:8000"));

--- a/docs/utilities/large_messages.md
+++ b/docs/utilities/large_messages.md
@@ -370,7 +370,7 @@ To interact with S3, the utility creates a default S3 Client :
 === "Default S3 Client"
     ```java
     S3Client client = S3Client.builder()
-                        .httpClient(UrlConnectionHttpClient.builder().build())
+                        .httpClient(AwsCrtHttpClient.builder().build())
                         .region(Region.of(System.getenv(AWS_REGION_ENV)))
                         .build();
     ```

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <log4j.version>2.22.0</log4j.version>
         <slf4j.version>2.0.7</slf4j.version>
         <jackson.version>2.15.3</jackson.version>
-        <aws.sdk.version>2.21.0</aws.sdk.version>
+        <aws.sdk.version>2.22.0</aws.sdk.version>
         <aws.xray.recorder.version>2.14.0</aws.xray.recorder.version>
         <payloadoffloading-common.version>2.1.3</payloadoffloading-common.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -183,6 +183,11 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>url-connection-client</artifactId>
+                <version>${aws.sdk.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>aws-crt-client</artifactId>
                 <version>${aws.sdk.version}</version>
             </dependency>
             <dependency>

--- a/powertools-idempotency/pom.xml
+++ b/powertools-idempotency/pom.xml
@@ -64,10 +64,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>url-connection-client</artifactId>
-            <version>${aws.sdk.version}</version>
+            <artifactId>aws-crt-client</artifactId>
         </dependency>
 
         <!-- Test dependencies -->
@@ -110,6 +110,12 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>DynamoDBLocal</artifactId>
             <version>[1.12,2.0)</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Needed for dynamoDB local telemetry -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
             <scope>test</scope>
         </dependency>
         <!--Needed when building locally on M1 Mac-->

--- a/powertools-idempotency/src/main/java/software/amazon/lambda/powertools/idempotency/persistence/DynamoDBPersistenceStore.java
+++ b/powertools-idempotency/src/main/java/software/amazon/lambda/powertools/idempotency/persistence/DynamoDBPersistenceStore.java
@@ -29,7 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -94,7 +94,7 @@ public class DynamoDBPersistenceStore extends BasePersistenceStore implements Pe
             String idempotencyDisabledEnv = System.getenv().get(Constants.IDEMPOTENCY_DISABLED_ENV);
             if (idempotencyDisabledEnv == null || "false".equalsIgnoreCase(idempotencyDisabledEnv)) {
                 this.dynamoDbClient = DynamoDbClient.builder()
-                        .httpClient(UrlConnectionHttpClient.builder().build())
+                        .httpClient(AwsCrtHttpClient.builder().build())
                         .overrideConfiguration(ClientOverrideConfiguration.builder()
                                 .putAdvancedOption(SdkAdvancedClientOption.USER_AGENT_SUFFIX,
                                         UserAgentConfigurator.getUserAgent(IDEMPOTENCY)).build())
@@ -419,7 +419,7 @@ public class DynamoDBPersistenceStore extends BasePersistenceStore implements Pe
 
         /**
          * Custom {@link DynamoDbClient} used to query DynamoDB (optional).<br/>
-         * The default one uses {@link UrlConnectionHttpClient} as a http client and
+         * The default one uses {@link AwsCrtHttpClient} as a http client and
          * add com.amazonaws.xray.interceptors.TracingInterceptor (X-Ray) if available in the classpath.
          *
          * @param dynamoDbClient the {@link DynamoDbClient} instance to use

--- a/powertools-idempotency/src/test/java/software/amazon/lambda/powertools/idempotency/DynamoDBConfig.java
+++ b/powertools-idempotency/src/test/java/software/amazon/lambda/powertools/idempotency/DynamoDBConfig.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
@@ -55,7 +55,7 @@ public class DynamoDBConfig {
         }
 
         client = DynamoDbClient.builder()
-                .httpClient(UrlConnectionHttpClient.builder().build())
+                .httpClient(AwsCrtHttpClient.builder().build())
                 .region(Region.EU_WEST_1)
                 .endpointOverride(URI.create("http://localhost:" + port))
                 .credentialsProvider(StaticCredentialsProvider.create(

--- a/powertools-large-messages/pom.xml
+++ b/powertools-large-messages/pom.xml
@@ -77,10 +77,8 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
-            <artifactId>url-connection-client</artifactId>
-            <version>${aws.sdk.version}</version>
+            <artifactId>aws-crt-client</artifactId>
         </dependency>
-
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/powertools-large-messages/src/main/java/software/amazon/lambda/powertools/largemessages/LargeMessageConfig.java
+++ b/powertools-large-messages/src/main/java/software/amazon/lambda/powertools/largemessages/LargeMessageConfig.java
@@ -16,7 +16,7 @@ package software.amazon.lambda.powertools.largemessages;
 
 import static software.amazon.lambda.powertools.common.internal.LambdaConstants.AWS_REGION_ENV;
 
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
@@ -74,7 +74,7 @@ public class LargeMessageConfig {
     public S3Client getS3Client() {
         if (this.s3Client == null) {
             S3ClientBuilder s3ClientBuilder = S3Client.builder()
-                    .httpClient(UrlConnectionHttpClient.builder().build())
+                    .httpClient(AwsCrtHttpClient.builder().build())
                     .region(Region.of(System.getenv(AWS_REGION_ENV)));
             this.s3Client = s3ClientBuilder.build();
         }


### PR DESCRIPTION
#1092

## Description of changes:

This PR changes the default SDK HTTP client from UrlConnectionClient to the AWS CRT client. The CRT client is a lightweight client which should reduce the cold start and latency of lambda functions.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
