### PR TITLE
fix(v2): Removing LambdaJsonLayout from logging config in examples

### DIFF
--- a/examples/powertools-examples-parameters/src/main/resources/log4j2.xml
+++ b/examples/powertools-examples-parameters/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
         <Console name="JsonAppender" target="SYSTEM_OUT">
-            <LambdaJsonLayout compact="true" eventEol="true"/>
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaJsonLayout.json" />
         </Console>
     </Appenders>
     <Loggers>

--- a/examples/powertools-examples-serialization/src/main/resources/log4j2.xml
+++ b/examples/powertools-examples-serialization/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
         <Console name="JsonAppender" target="SYSTEM_OUT">
-            <LambdaJsonLayout compact="true" eventEol="true"/>
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaJsonLayout.json" />
         </Console>
     </Appenders>
     <Loggers>

--- a/powertools-tracing/src/test/resources/log4j2.xml
+++ b/powertools-tracing/src/test/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration packages="com.amazonaws.services.lambda.runtime.log4j2">
     <Appenders>
         <File name="JsonAppender" fileName="target/logfile.json">
-            <LambdaJsonLayout compact="true" eventEol="true"/>
+            <JsonTemplateLayout eventTemplateUri="classpath:LambdaJsonLayout.json" />
         </File>
     </Appenders>
     <Loggers>


### PR DESCRIPTION
**Issue #, if available:**
[issue](https://github.com/aws-powertools/powertools-lambda-java/issues/1543)
## Description of changes:
Replaced the LambdaJsonLayout with JsonTemplateLayout as mentioned [powertools-lambda-java/docs/core/logging.md](https://github.com/aws-powertools/powertools-lambda-java/blob/fb14bcfee1aae8e03b8c8081b2478edefc9b5b87/docs/core/logging.md?plain=1#L211-L215)
<!--- One or two sentences as a summary of what's being changed -->
The log4j2.xml for couple of examples is changed as they were missed earlier.
**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
