### PR TITLE
chore: dependabot on v2 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,12 @@ updates:
       # Ignore Mockito 5.X.X as it does not support Java 8
       - dependency-name: "org.mockito:mockito-*"
         update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "maven"
+    directory: "/"
+    target-branch: "v2"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "maven"
+      - "dependencies"


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Enable dependabot on v2 branch

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
