### PR TITLE
fix(v2): Fix params builder to provide default transformation manager

### DIFF
--- a/powertools-parameters/pom.xml
+++ b/powertools-parameters/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
-            <scope>provided</scope>
+            <version>${aspectj.version}</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.lambda</groupId>
@@ -48,6 +48,7 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/powertools-parameters/pom.xml
+++ b/powertools-parameters/pom.xml
@@ -48,7 +48,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/powertools-parameters/pom.xml
+++ b/powertools-parameters/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
-            <version>${aspectj.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>software.amazon.lambda</groupId>

--- a/powertools-parameters/powertools-parameters-appconfig/src/main/java/software/amazon/lambda/powertools/parameters/appconfig/AppConfigProviderBuilder.java
+++ b/powertools-parameters/powertools-parameters-appconfig/src/main/java/software/amazon/lambda/powertools/parameters/appconfig/AppConfigProviderBuilder.java
@@ -51,7 +51,9 @@ public class AppConfigProviderBuilder {
         if (application == null) {
             throw new IllegalStateException("No application provided; please provide one");
         }
-
+        if (transformationManager == null) {
+            transformationManager = new TransformationManager();
+        }
         // Create a AppConfigDataClient if we haven't been given one
         if (client == null) {
             client = AppConfigDataClient.builder()

--- a/powertools-parameters/powertools-parameters-appconfig/src/test/java/software/amazon/lambda/powertools/parameters/appconfig/AppConfigProviderTest.java
+++ b/powertools-parameters/powertools-parameters-appconfig/src/test/java/software/amazon/lambda/powertools/parameters/appconfig/AppConfigProviderTest.java
@@ -17,7 +17,9 @@ package software.amazon.lambda.powertools.parameters.appconfig;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatRuntimeException;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.MockitoAnnotations.openMocks;
+import static software.amazon.lambda.powertools.parameters.transform.Transformer.json;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -215,5 +217,16 @@ public class AppConfigProviderTest {
                         .withClient(client)
                         .build())
                 .withMessage("No application provided; please provide one");
+    }
+    @Test
+    public void testAppConfigProvider_withoutParameter_shouldHaveDefaultTransformationManager() {
+
+        // Act
+        AppConfigProvider appConfigProvider = AppConfigProvider.builder()
+                .withEnvironment("test")
+                .withApplication("app")
+                .build();
+        // Assert
+        assertDoesNotThrow(()->appConfigProvider.withTransformation(json));
     }
 }

--- a/powertools-parameters/powertools-parameters-dynamodb/src/main/java/software/amazon/lambda/powertools/parameters/dynamodb/DynamoDbProviderBuilder.java
+++ b/powertools-parameters/powertools-parameters-dynamodb/src/main/java/software/amazon/lambda/powertools/parameters/dynamodb/DynamoDbProviderBuilder.java
@@ -61,6 +61,9 @@ public class DynamoDbProviderBuilder {
         if (client == null) {
             client = createClient();
         }
+        if (transformationManager == null) {
+            transformationManager = new TransformationManager();
+        }
         provider = new DynamoDbProvider(cacheManager, transformationManager, client, table);
 
         return provider;

--- a/powertools-parameters/powertools-parameters-dynamodb/src/test/java/software/amazon/lambda/powertools/parameters/dynamodb/DynamoDbProviderTest.java
+++ b/powertools-parameters/powertools-parameters-dynamodb/src/test/java/software/amazon/lambda/powertools/parameters/dynamodb/DynamoDbProviderTest.java
@@ -16,7 +16,9 @@ package software.amazon.lambda.powertools.parameters.dynamodb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.MockitoAnnotations.openMocks;
+import static software.amazon.lambda.powertools.parameters.transform.Transformer.json;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -224,6 +226,15 @@ public class DynamoDbProviderTest {
         assertThatIllegalStateException().isThrownBy(() -> DynamoDbProvider.builder()
                 .withCacheManager(new CacheManager())
                 .build());
+    }
+    @Test
+    public void testDynamoDBBuilder_withoutParameter_shouldHaveDefaultTransformationManager() {
+
+        // Act
+        DynamoDbProvider dynamoDbProvider = DynamoDbProvider.builder().withTable("test-table")
+                .build();
+        // Assert
+        assertDoesNotThrow(()->dynamoDbProvider.withTransformation(json));
     }
 
 }

--- a/powertools-parameters/powertools-parameters-secrets/src/main/java/software/amazon/lambda/powertools/parameters/secrets/SecretsProviderBuilder.java
+++ b/powertools-parameters/powertools-parameters-secrets/src/main/java/software/amazon/lambda/powertools/parameters/secrets/SecretsProviderBuilder.java
@@ -59,7 +59,9 @@ public class SecretsProviderBuilder {
         if (client == null) {
             client = createClient();
         }
-
+        if(transformationManager == null){
+            transformationManager = new TransformationManager();
+        }
         provider = new SecretsProvider(cacheManager, transformationManager, client);
 
         return provider;

--- a/powertools-parameters/powertools-parameters-secrets/src/test/java/software/amazon/lambda/powertools/parameters/secrets/SecretsProviderTest.java
+++ b/powertools-parameters/powertools-parameters-secrets/src/test/java/software/amazon/lambda/powertools/parameters/secrets/SecretsProviderTest.java
@@ -16,10 +16,13 @@ package software.amazon.lambda.powertools.parameters.secrets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatRuntimeException;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static software.amazon.lambda.powertools.parameters.transform.Transformer.json;
 
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -104,5 +107,15 @@ public class SecretsProviderTest {
         // Assert
         assertNotNull(secretsProvider);
         assertNotNull(secretsProvider.getClient());
+    }
+
+    @Test
+    public void testGetSecretsProvider_withoutParameter_shouldHaveDefaultTransformationManager() {
+
+        // Act
+        SecretsProvider secretsProvider = SecretsProvider.builder()
+                .build();
+        // Assert
+        assertDoesNotThrow(()->secretsProvider.withTransformation(json));
     }
 }

--- a/powertools-parameters/powertools-parameters-ssm/src/main/java/software/amazon/lambda/powertools/parameters/ssm/SSMProviderBuilder.java
+++ b/powertools-parameters/powertools-parameters-ssm/src/main/java/software/amazon/lambda/powertools/parameters/ssm/SSMProviderBuilder.java
@@ -57,6 +57,9 @@ public class SSMProviderBuilder {
             client = createClient();
         }
 
+        if(transformationManager == null){
+            transformationManager = new TransformationManager();
+        }
         provider = new SSMProvider(cacheManager, transformationManager, client);
 
         return provider;

--- a/powertools-parameters/powertools-parameters-ssm/src/test/java/software/amazon/lambda/powertools/parameters/ssm/SSMProviderTest.java
+++ b/powertools-parameters/powertools-parameters-ssm/src/test/java/software/amazon/lambda/powertools/parameters/ssm/SSMProviderTest.java
@@ -16,6 +16,8 @@ package software.amazon.lambda.powertools.parameters.ssm;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static software.amazon.lambda.powertools.parameters.transform.Transformer.json;
 
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -192,6 +194,16 @@ public class SSMProviderTest {
 
         assertThat(request1.nextToken()).isNull();
         assertThat(request2.nextToken()).isEqualTo("123abc");
+    }
+
+    @Test
+    public void testSSMProvider_withoutParameter_shouldHaveDefaultTransformationManager() {
+
+        // Act
+        SSMProvider ssmProvider = SSMProvider.builder()
+                .build();
+        // Assert
+        assertDoesNotThrow(()->ssmProvider.withTransformation(json));
     }
 
     private void initMock(String expectedValue) {


### PR DESCRIPTION
**Issue #, if available:**
[issue](https://github.com/aws-powertools/powertools-lambda-java/issues/1544)
## Description of changes:
Add default transformation manager in params builders
<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
