### PR TITLE
build(deps): bump com.fasterxml.jackson from 2.15.3 to 2.16.0 and com.amazonaws.xray from 2.14.0 to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,9 +89,9 @@
         <log4j.version>2.20.0</log4j.version>
         <log4j.version>2.22.0</log4j.version>
         <slf4j.version>2.0.7</slf4j.version>
-        <jackson.version>2.15.3</jackson.version>
+        <jackson.version>2.16.0</jackson.version>
         <aws.sdk.version>2.21.0</aws.sdk.version>
-        <aws.xray.recorder.version>2.14.0</aws.xray.recorder.version>
+        <aws.xray.recorder.version>2.15.0</aws.xray.recorder.version>
         <payloadoffloading-common.version>2.1.3</payloadoffloading-common.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <lambda.core.version>1.2.3</lambda.core.version>


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws-powertools/powertools-lambda-java/issues/1538

## Description of changes:
Update dversions 
Jackson to 2.16.0 and 
AWS Xray to 2.15.0

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [X ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

The issue description says these could be breaking changes. 
I did not see any compile errors or breaking unit tests after updating maven dependencies locally on v2 branch.

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
