### PR TITLE
chore(v2): document use of aws-crt-client (#1092)

### DIFF
--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -49,7 +49,7 @@ To enable `forceAjcCompile` you need to use following `aspectj-maven-plugin` con
 
 ## How can I use Powertools for AWS Lambda (Java) with the AWS CRT HTTP Client?
 
-Powertools uses the `url-connection-client` as the default http client. The `url-connection-client` is a lightweight http client, which keeps the impact on Lambda cold starts to a minimum. 
+Powertools uses the `url-connection-client` as the default HTTP client. The `url-connection-client` is a lightweight HTTP client, which keeps the impact on Lambda cold starts to a minimum. 
 With the [announcement](https://aws.amazon.com/blogs/developer/announcing-availability-of-the-aws-crt-http-client-in-the-aws-sdk-for-java-2-x/) of the `aws-crt-client` a new http client has been released, which offers faster SDK startup time and smaller memory footprint. 
 
 Unfortunately, replacing the `url-connection-client` dependency with the `aws-crt-client` will not immediately improve the lambda cold start performance and memory footprint, 

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -72,7 +72,7 @@ Using the `aws-crt-client` in your project requires the exclusion of the `url-co
 ```
 Next, add the `aws-crt-client` and exclude the "generic" `aws-crt` dependency (contains all runtime libraries). 
 Instead, set a specific classifier of the `aws-crt` to use the one for your target runtime: either `linux-x86_64` for a Lambda configured for x86 or `linux-aarch_64` for Lambda using arm64.
-Specifying the specific target runtime makes sure all other target runtimes are excluded from the jar file, which will result in the benefit of improved cold start times.   
+By specifying the specific target runtime, it will avoid other target runtimes to be included in the jar file, which will result in a smaller Lambda package and the benefit of improved cold start times.   
 
 ```xml
 

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -103,7 +103,7 @@ By specifying the specific target runtime, we prevent other target runtimes from
 ```
 
 ### Explicitly set the AWS CRT HTTP Client
-After configuring the dependencies, it's required to explicitly specify the AWS SDK http client. 
+After configuring the dependencies, it's required to explicitly specify the AWS SDK HTTP client. 
 Depending on the Powertools module, there is a different way to configure the sdk client.
 
 The following example shows how to use the Lambda Powertools Parameters module while leveraging the AWS CRT Client.   

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -53,7 +53,7 @@ Powertools uses the `url-connection-client` as the default HTTP client. The `url
 With the [announcement](https://aws.amazon.com/blogs/developer/announcing-availability-of-the-aws-crt-http-client-in-the-aws-sdk-for-java-2-x/) of the `aws-crt-client` a new HTTP client has been released, which offers faster SDK startup time and smaller memory footprint. 
 
 Unfortunately, replacing the `url-connection-client` dependency with the `aws-crt-client` will not immediately improve the lambda cold start performance and memory footprint, 
-as the default version of the dependency contains low level libraries for all target runtimes (Linux, MacOS, Windows, etc).  
+as the default version of the dependency contains native system libraries for all supported runtimes and architectures (Linux, MacOS, Windows, AMD64, ARM64, etc).  This makes the CRT client portable, without the user having to consider _where_ their code will run, but comes at the cost of JAR size.
 
 ### Configuring dependencies
 

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -50,7 +50,7 @@ To enable `forceAjcCompile` you need to use following `aspectj-maven-plugin` con
 ## How can I use Powertools for AWS Lambda (Java) with the AWS CRT HTTP Client?
 
 Powertools uses the `url-connection-client` as the default HTTP client. The `url-connection-client` is a lightweight HTTP client, which keeps the impact on Lambda cold starts to a minimum. 
-With the [announcement](https://aws.amazon.com/blogs/developer/announcing-availability-of-the-aws-crt-http-client-in-the-aws-sdk-for-java-2-x/) of the `aws-crt-client` a new http client has been released, which offers faster SDK startup time and smaller memory footprint. 
+With the [announcement](https://aws.amazon.com/blogs/developer/announcing-availability-of-the-aws-crt-http-client-in-the-aws-sdk-for-java-2-x/) of the `aws-crt-client` a new HTTP client has been released, which offers faster SDK startup time and smaller memory footprint. 
 
 Unfortunately, replacing the `url-connection-client` dependency with the `aws-crt-client` will not immediately improve the lambda cold start performance and memory footprint, 
 as the default version of the dependency contains low level libraries for all target runtimes (Linux, MacOS, Windows, etc).  

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -63,7 +63,7 @@ Using the `aws-crt-client` in your project requires the exclusion of the `url-co
 <dependency>
     <groupId>software.amazon.lambda</groupId>
     <artifactId>powertools-parameters</artifactId>
-    <version>1.18.0</version>
+    <version>2.0.0</version>
     <exclusions>
         <exclusion>
             <groupId>software.amazon.awssdk</groupId>

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -53,7 +53,9 @@ Powertools uses the `url-connection-client` as the default http client. The `url
 With the [announcement](https://aws.amazon.com/blogs/developer/announcing-availability-of-the-aws-crt-http-client-in-the-aws-sdk-for-java-2-x/) of the `aws-crt-client` a new http client has been released, which offers faster SDK startup time and smaller memory footprint. 
 
 Unfortunately, replacing the `url-connection-client` dependency with the `aws-crt-client` will not immediately improve the lambda cold start performance and memory footprint, 
-as the default version of the dependency contains low level libraries for all target runtimes (linux, macos, windows, etc).  
+as the default version of the dependency contains low level libraries for all target runtimes (Linux, MacOS, Windows, etc).  
+
+### Configuring dependencies
 
 Using the `aws-crt-client` in your project requires the exclusion of the `url-connection-client` transitive dependency from the powertools dependency. 
 
@@ -98,8 +100,11 @@ By specifying the specific target runtime, it will avoid other target runtimes t
 </dependencies>
 ```
 
-After configuring the dependencies, it's required to specify the AWS SDK http client in the code. 
-Most modules support a custom sdk client by leveraging the `.withClient()` method on the for instance the Provider singleton:
+### Explicitly set the AWS CRT HTTP Client
+After configuring the dependencies, it's required to explicitly specify the AWS SDK http client. 
+Depending on the Powertools module, there is a different way to configure the sdk client.
+
+The following example shows how to use the Lambda Powertools Parameters module while leveraging the AWS CRT Client.   
 
     ```java hl_lines="11-16 19-20 22"
     import static software.amazon.lambda.powertools.parameters.transform.Transformer.base64;
@@ -107,12 +112,12 @@ Most modules support a custom sdk client by leveraging the `.withClient()` metho
     import com.amazonaws.services.lambda.runtime.Context;
     import com.amazonaws.services.lambda.runtime.RequestHandler;
     import software.amazon.awssdk.services.ssm.SsmClient;
+    import software.amazon.awssdk.http.crt.AwsCrtHttpClient;
     import software.amazon.lambda.powertools.parameters.ssm.SSMProvider;
 
     public class RequestHandlerWithParams implements RequestHandler<String, String> {
     
-        // Get an instance of the SSMProvider. We can provide a custom client here if we want,
-        // for instance to use the aws crt http client.
+        // Get an instance of the SSMProvider with a custom HTTP client (aws crt).
         SSMProvider ssmProvider = SSMProvider
                 .builder()
                 .withClient(

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -73,7 +73,9 @@ Using the `aws-crt-client` in your project requires the exclusion of the `url-co
 </dependency>
 ```
 Next, add the `aws-crt-client` and exclude the "generic" `aws-crt` dependency (contains all runtime libraries). 
-Instead, set a specific classifier of the `aws-crt` to use the one for your target runtime: either `linux-x86_64` for a Lambda configured for x86 or `linux-aarch_64` for Lambda using arm64.
+Instead, set a specific classifier of the `aws-crt` to use the one for your target runtime: either `linux-x86_64` for a Lambda configured for x86 or `linux-aarch_64` for Lambda using arm64. 
+
+!!! note "You will need to add a separate maven profile to build and debug locally when your development environment does not share the target architecture you are using in Lambda."
 By specifying the specific target runtime, we prevent other target runtimes from being included in the jar file, resulting in a smaller Lambda package and improved cold start times.
 
 ```xml

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -74,7 +74,7 @@ Using the `aws-crt-client` in your project requires the exclusion of the `url-co
 ```
 Next, add the `aws-crt-client` and exclude the "generic" `aws-crt` dependency (contains all runtime libraries). 
 Instead, set a specific classifier of the `aws-crt` to use the one for your target runtime: either `linux-x86_64` for a Lambda configured for x86 or `linux-aarch_64` for Lambda using arm64.
-By specifying the specific target runtime, it will avoid other target runtimes to be included in the jar file, which will result in a smaller Lambda package and the benefit of improved cold start times.   
+By specifying the specific target runtime, we prevent other target runtimes from being included in the jar file, resulting in a smaller Lambda package and improved cold start times.
 
 ```xml
 

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -98,7 +98,7 @@ By specifying the specific target runtime, it will avoid other target runtimes t
 </dependencies>
 ```
 
-After configuring the dependencies it's required to specify the aws sdk http client. 
+After configuring the dependencies, it's required to specify the AWS SDK http client in the code. 
 Most modules support a custom sdk client by leveraging the `.withClient()` method on the for instance the Provider singleton:
 
     ```java hl_lines="11-16 19-20 22"

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -104,7 +104,7 @@ By specifying the specific target runtime, we prevent other target runtimes from
 
 ### Explicitly set the AWS CRT HTTP Client
 After configuring the dependencies, it's required to explicitly specify the AWS SDK HTTP client. 
-Depending on the Powertools module, there is a different way to configure the sdk client.
+Depending on the Powertools module, there is a different way to configure the SDK client.
 
 The following example shows how to use the Lambda Powertools Parameters module while leveraging the AWS CRT Client.   
 

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -70,7 +70,8 @@ Using the `aws-crt-client` in your project requires the exclusion of the `url-co
     </exclusions>
 </dependency>
 ```
-Next to adding the `aws-crt-client` and excluding the `aws-crt` dependency (contain all runtime libraries) it's required to set a specific runtime version of the `aws-crt` dependency by specifying the classifier for your specific target runtime.
+Next, add the `aws-crt-client` and exclude the "generic" `aws-crt` dependency (contains all runtime libraries). 
+Instead, set a specific classifier of the `aws-crt` to use the one for your target runtime: either `linux-x86_64` for a Lambda configured for x86 or `linux-aarch_64` for Lambda using arm64.
 Specifying the specific target runtime makes sure all other target runtimes are excluded from the jar file, which will result in the benefit of improved cold start times.   
 
 ```xml

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -141,5 +141,5 @@ The following example shows how to use the Lambda Powertools Parameters module w
         }
     }
     ```
-It has been considered to make the `aws-crt-client` the default http client in Lambda Powertools for Java, as mentioned in [Move SDK http client to CRT](https://github.com/aws-powertools/powertools-lambda-java/issues/1092), 
+The `aws-crt-client` was considered for adoption as the default HTTP client in Lambda Powertools for Java as mentioned in [Move SDK http client to CRT](https://github.com/aws-powertools/powertools-lambda-java/issues/1092), 
 but due to the impact on the developer experience it was decided to stick with the `url-connection-client`. 

--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -530,19 +530,19 @@ Handlers can be provided when building the batch processor and are available for
 For instance for DynamoDB:
 
 ```java
-BatchMessageHandler<DynamodbEvent, StreamsEventResponse> handler = new BatchMessageHandlerBuilder()
-            .withDynamoDbBatchHandler()
-            .withSuccessHandler((m) -> {
-                // Success handler receives the raw message
-                LOGGER.info("Message with sequenceNumber {} was successfully processed",
-                    m.getDynamodb().getSequenceNumber());
-            })
-            .withFailureHandler((m, e) -> {
-                // Failure handler receives the raw message and the exception thrown.
-                LOGGER.info("Message with sequenceNumber {} failed to be processed: {}"
-                , e.getDynamodb().getSequenceNumber(), e);
-            })
-            .buildWithMessageHander(this::processMessage);
+    BatchMessageHandler<DynamodbEvent, StreamsEventResponse> handler = new BatchMessageHandlerBuilder()
+                .withDynamoDbBatchHandler()
+                .withSuccessHandler((m) -> {
+                    // Success handler receives the raw message
+                    LOGGER.info("Message with sequenceNumber {} was successfully processed",
+                        m.getDynamodb().getSequenceNumber());
+                })
+                .withFailureHandler((m, e) -> {
+                    // Failure handler receives the raw message and the exception thrown.
+                    LOGGER.info("Message with sequenceNumber {} failed to be processed: {}"
+                    , e.getDynamodb().getSequenceNumber(), e);
+                })
+                .buildWithMessageHander(this::processMessage);
 ```
 
 !!! info

--- a/docs/utilities/large_messages.md
+++ b/docs/utilities/large_messages.md
@@ -97,48 +97,49 @@ of amazon-sns-java-extended-client-lib.
 Depending on your version of Java (either Java 1.8 or 11+), the configuration slightly changes.
 
 === "Maven Java 11+"
-```xml hl_lines="3-7 16 18 24-27"
-<dependencies>
-...
-<dependency>
-<groupId>software.amazon.lambda</groupId>
-<artifactId>powertools-large-messages</artifactId>
-<version>{{ powertools.version }}</version>
-</dependency>
-...
-</dependencies>
-...
-<!-- configure the aspectj-maven-plugin to compile-time weave (CTW) the aws-lambda-powertools-java aspects into your project -->
-<build>
-<plugins>
-...
-<plugin>
-<groupId>dev.aspectj</groupId>
-<artifactId>aspectj-maven-plugin</artifactId>
-<version>1.13.1</version>
-<configuration>
-<source>11</source> <!-- or higher -->
-<target>11</target> <!-- or higher -->
-<complianceLevel>11</complianceLevel> <!-- or higher -->
-<aspectLibraries>
-<aspectLibrary>
-<groupId>software.amazon.lambda</groupId>
-<artifactId>powertools-large-messages</artifactId>
-</aspectLibrary>
-</aspectLibraries>
-</configuration>
-<executions>
-<execution>
-<goals>
-<goal>compile</goal>
-</goals>
-</execution>
-</executions>
-</plugin>
-...
-</plugins>
-</build>
-```
+
+    ```xml hl_lines="3-7 16 18 24-27"
+    <dependencies>
+        ...
+        <dependency>
+            <groupId>software.amazon.lambda</groupId>
+            <artifactId>powertools-large-messages</artifactId>
+            <version>{{ powertools.version }}</version>
+        </dependency>
+        ...
+    </dependencies>
+    ...
+    <!-- configure the aspectj-maven-plugin to compile-time weave (CTW) the aws-lambda-powertools-java aspects into your project -->
+    <build>
+        <plugins>
+            ...
+            <plugin>
+                <groupId>dev.aspectj</groupId>
+                <artifactId>aspectj-maven-plugin</artifactId>
+                <version>1.13.1</version>
+                <configuration>
+                    <source>11</source> <!-- or higher -->
+                    <target>11</target> <!-- or higher -->
+                    <complianceLevel>11</complianceLevel> <!-- or higher -->
+                    <aspectLibraries>
+                        <aspectLibrary>
+                            <groupId>software.amazon.lambda</groupId>
+                            <artifactId>powertools-large-messages</artifactId>
+                        </aspectLibrary>
+                    </aspectLibraries>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            ...
+        </plugins>
+    </build>
+    ```
 
 === "Maven Java 1.8"
 

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -544,6 +544,7 @@ To simplify the use of the library, you can chain all method calls before a get.
           .withTransformation(json)       // json is a static import from Transformer.json
           .withDecryption()               // enable decryption of the parameter value
           .get("/my/param", MyObj.class); // finally get the value
+    ```
 
 ### Create your own Provider
 You can create your own custom parameter store provider by implementing a handful of classes: 


### PR DESCRIPTION
**Issue #, if available:** #1092

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->
- Added documentation for using the aws-crt-client with powertools (v2).
- Fixed some documentation issues with typos and code blocks.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [x] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
