### PR TITLE
feat(build): remove java 8 support in v2

### DIFF
--- a/.github/workflows/pr_build_v2.yml
+++ b/.github/workflows/pr_build_v2.yml
@@ -3,11 +3,11 @@ name: Build
 on:
   pull_request:
     branches:
-      - main
+      - v2
     paths:
       - 'powertools-batch/**'
       - 'powertools-cloudformation/**'
-      - 'powertools-core/**'
+      - 'powertools-common/**'
       - 'powertools-e2e-tests/**'
       - 'powertools-idempotency/**'
       - 'powertools-large-messages/**'
@@ -15,8 +15,6 @@ on:
       - 'powertools-metrics/**'
       - 'powertools-parameters/**'
       - 'powertools-serialization/**'
-      - 'powertools-sqs/**'
-      - 'powertools-test-suite/**'
       - 'powertools-tracing/**'
       - 'powertools-validation/**'
       - 'examples/**'
@@ -25,11 +23,11 @@ on:
       - '.github/workflows/**'
   push:
     branches:
-      - main
+      - v2
     paths:
       - 'powertools-batch/**'
       - 'powertools-cloudformation/**'
-      - 'powertools-core/**'
+      - 'powertools-common/**'
       - 'powertools-e2e-tests/**'
       - 'powertools-idempotency/**'
       - 'powertools-large-messages/**'
@@ -37,8 +35,6 @@ on:
       - 'powertools-metrics/**'
       - 'powertools-parameters/**'
       - 'powertools-serialization/**'
-      - 'powertools-sqs/**'
-      - 'powertools-test-suite/**'
       - 'powertools-tracing/**'
       - 'powertools-validation/**'
       - 'examples/**'
@@ -51,7 +47,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        java: [8, 11, 17, 21]
+        java: [11, 17, 21]
     name: Java ${{ matrix.java }}
     env:
       JAVA: ${{ matrix.java }}
@@ -70,11 +66,9 @@ jobs:
       - name: Build with Maven
         run: mvn -B install --file pom.xml
       - name: Build Gradle Example - Java
-        if: ${{ matrix.java == '8' }} # Gradle example can only be built on Java 8
         working-directory: examples/powertools-examples-core/gradle
         run: ./gradlew build
       - name: Build Gradle Example - Kotlin
-        if: ${{ matrix.java == '8' }} # Gradle example can only be built on Java 8
         working-directory: examples/powertools-examples-core/kotlin
         run: ./gradlew build
       - name: Upload coverage to Codecov

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # v3.11.0
         with:
           distribution: 'corretto'
-          java-version: 11
+          java-version: 8
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # v3.11.0
         with:
           distribution: 'corretto'
-          java-version: 8
+          java-version: 11
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/run-e2e-tests-v2.yml
+++ b/.github/workflows/run-e2e-tests-v2.yml
@@ -5,7 +5,7 @@ on:
 
   push:
     branches:
-      - main
+      - v2
     paths: # add other modules when there are under e2e tests
       - 'powertools-e2e-tests/**'
       - 'powertools-batch/**'
@@ -23,7 +23,7 @@ on:
 
   pull_request:
     branches:
-      - main
+      - v2
     paths:
       - 'powertools-e2e-tests/**'
 
@@ -33,7 +33,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        java: [ 8, 11, 17, 21 ]
+        java: [ 11, 17, 21 ]
     name: End-to-end tests java${{ matrix.java }}
     env:
       AWS_DEFAULT_REGION: eu-west-1


### PR DESCRIPTION
**Issue #, if available:** #1523

## Description of changes:

Remove java 8 builds for pr and e2e tests github actions in v2.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

not yet a breaking change (just the github actions)

**RFC issue #**:  #1523

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
