### PR TITLE
docs: add link to Powertools for AWS Lambda workshop

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ site_url: https://docs.powertools.aws.dev/lambda-java/
 nav:
   - Homepage: index.md
   - Changelog: changelog.md
+  - Workshop 🆕: https://s12d.com/powertools-for-aws-lambda-workshop" target="_blank
   - FAQs: FAQs.md
   - Core utilities:
       - core/logging.md


### PR DESCRIPTION
**Issue #, if available:** #1640

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

This PR adds a link to the Powertools for AWS Lambda workshop in the documentation sidebar. This will allow customers to know about the existence of the workshop.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
