### PR TITLE
fix: Allow empty responses as well as null response in AppConfig

### DIFF
--- a/powertools-parameters/src/main/java/software/amazon/lambda/powertools/parameters/AppConfigProvider.java
+++ b/powertools-parameters/src/main/java/software/amazon/lambda/powertools/parameters/AppConfigProvider.java
@@ -29,6 +29,8 @@ import software.amazon.lambda.powertools.core.internal.UserAgentConfigurator;
 import software.amazon.lambda.powertools.parameters.cache.CacheManager;
 import software.amazon.lambda.powertools.parameters.transform.TransformationManager;
 
+import static software.amazon.awssdk.utils.StringUtils.isBlank;
+
 /**
  * Implements a {@link ParamProvider} on top of the AppConfig service. AppConfig provides
  * a mechanism to retrieve and update configuration of applications over time.
@@ -98,7 +100,7 @@ public class AppConfigProvider extends BaseProvider {
         // Get the value of the key. Note that AppConfig will return null if the value
         // has not changed since we last asked for it in this session - in this case
         // we return the value we stashed at last request.
-        String value = response.configuration() != null ?
+        String value = response.configuration() != null && response.configuration().asByteArray().length > 0 ?
                 response.configuration().asUtf8String() : // if we have a new value, use it
                 establishedSession != null ?
                         establishedSession.lastConfigurationValue :

--- a/powertools-parameters/src/test/java/software/amazon/lambda/powertools/parameters/AppConfigProviderTest.java
+++ b/powertools-parameters/src/test/java/software/amazon/lambda/powertools/parameters/AppConfigProviderTest.java
@@ -90,21 +90,29 @@ public class AppConfigProviderTest {
         GetLatestConfigurationResponse thirdResponse = GetLatestConfigurationResponse.builder()
                 .nextPollConfigurationToken("token4")
                 .build();
+        // Forth response returns empty, which means the provider should yield the previous value again
+        GetLatestConfigurationResponse forthResponse = GetLatestConfigurationResponse.builder()
+                .nextPollConfigurationToken("token5")
+                .configuration(SdkBytes.fromUtf8String(""))
+                .build();
         Mockito.when(client.startConfigurationSession(startSessionRequestCaptor.capture()))
                 .thenReturn(firstSession);
         Mockito.when(client.getLatestConfiguration(getLatestConfigurationRequestCaptor.capture()))
-                .thenReturn(firstResponse, secondResponse, thirdResponse);
+                .thenReturn(firstResponse, secondResponse, thirdResponse, forthResponse);
 
         // Act
         String returnedValue1 = provider.getValue(defaultTestKey);
         String returnedValue2 = provider.getValue(defaultTestKey);
         String returnedValue3 = provider.getValue(defaultTestKey);
+        String returnedValue4 = provider.getValue(defaultTestKey);
 
         // Assert
         assertThat(returnedValue1).isEqualTo(firstResponse.configuration().asUtf8String());
         assertThat(returnedValue2).isEqualTo(secondResponse.configuration().asUtf8String());
         assertThat(returnedValue3).isEqualTo(secondResponse.configuration()
                 .asUtf8String()); // Third response is mocked to return null and should re-use previous value
+        assertThat(returnedValue4).isEqualTo(secondResponse.configuration()
+                .asUtf8String()); // Forth response is mocked to return empty and should re-use previous value
         assertThat(startSessionRequestCaptor.getValue().applicationIdentifier()).isEqualTo(applicationName);
         assertThat(startSessionRequestCaptor.getValue().environmentIdentifier()).isEqualTo(environmentName);
         assertThat(startSessionRequestCaptor.getValue().configurationProfileIdentifier()).isEqualTo(defaultTestKey);


### PR DESCRIPTION
**Issue #, if available:**

https://github.com/aws-powertools/powertools-lambda-java/issues/1672

## Description of changes:

When checking for empty response from AWS AppConfig data plane, check whether response is an empty byte array rather as well as `null`.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
