### PR TITLE
build(deps): bump com.networknt:json-schema-validator from 1.0.87 to 1.4.3

### DIFF
--- a/docs/utilities/validation.md
+++ b/docs/utilities/validation.md
@@ -83,7 +83,9 @@ You can validate inbound and outbound events using `@Validation` annotation.
 
 You can also use the `Validator#validate()` methods, if you want more control over the validation process such as handling a validation error.
 
-We support JSON schema version 4, 6, 7 and 201909 (from [jmespath-jackson library](https://github.com/burtcorp/jmespath-java)).
+We support JSON schema version 4, 6, 7, 2019-09 and 2020-12 using the [NetworkNT JSON Schema Validator](https://github.com/networknt/json-schema-validator). ([Compatibility with JSON Schema versions](https://github.com/networknt/json-schema-validator/blob/master/doc/compatibility.md)).
+
+The validator is configured to enable format assertions by default even for 2019-09 and 2020-12.
 
 ### Validation annotation
 
@@ -228,7 +230,8 @@ and [function](https://jmespath.org/tutorial.html#functions) expressions, where 
 
 
 ## Change the schema version
-By default, powertools-validation is configured with [V7](https://json-schema.org/draft-07/json-schema-release-notes.html).
+By default, powertools-validation is configured to use [V7](https://json-schema.org/draft-07/json-schema-release-notes.html) as the default dialect if [`$schema`](https://json-schema.org/understanding-json-schema/reference/schema#schema) is not explicitly specified within the schema. If [`$schema`](https://json-schema.org/understanding-json-schema/reference/schema#schema) is explicitly specified within the schema, the validator will use the specified dialect.
+
 You can use the `ValidationConfig` to change that behaviour.
 
 === "Handler with custom schema version"

--- a/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/ValidationALBE2ET.java
+++ b/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/ValidationALBE2ET.java
@@ -85,7 +85,7 @@ class ValidationALBE2ET {
 		// THEN
 		// invocation should fail inbound validation and return an error message
 		JsonNode validJsonNode = objectMapper.readTree(invocationResult.getResult());
-		assertThat(validJsonNode.get("errorMessage").asText()).contains("$.price: is missing but it is required");
+		assertThat(validJsonNode.get("errorMessage").asText()).contains(": required property 'price' not found");
 	}
 
 	@Test
@@ -99,6 +99,6 @@ class ValidationALBE2ET {
 		// THEN
 		// invocation should fail outbound validation and return 400
 		JsonNode validJsonNode = objectMapper.readTree(invocationResult.getResult());
-		assertThat(validJsonNode.get("errorMessage").asText()).contains("$.price: must have an exclusive maximum value of 1000");
+		assertThat(validJsonNode.get("errorMessage").asText()).contains("/price: must have an exclusive maximum value of 1000");
 	}
 }

--- a/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/ValidationApiGWE2ET.java
+++ b/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/ValidationApiGWE2ET.java
@@ -86,7 +86,7 @@ class ValidationApiGWE2ET {
 		// invocation should fail inbound validation and return 400
 		JsonNode validJsonNode = objectMapper.readTree(invocationResult.getResult());
 		assertThat(validJsonNode.get("statusCode").asInt()).isEqualTo(400);
-		assertThat(validJsonNode.get("body").asText()).contains("$.price: is missing but it is required");
+		assertThat(validJsonNode.get("body").asText()).contains(": required property 'price' not found");
 	}
 
 	@Test
@@ -102,6 +102,6 @@ class ValidationApiGWE2ET {
 		JsonNode validJsonNode = objectMapper.readTree(invocationResult.getResult());
 		assertThat(validJsonNode.get("statusCode").asInt()).isEqualTo(400);
 		assertThat(validJsonNode.get("body").asText())
-				.contains("$.price: must have an exclusive maximum value of 1000");
+				.contains("/price: must have an exclusive maximum value of 1000");
 	}
 }

--- a/powertools-validation/pom.xml
+++ b/powertools-validation/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <version>1.0.87</version>
+            <version>1.4.3</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/powertools-validation/src/main/java/software/amazon/lambda/powertools/validation/ValidationConfig.java
+++ b/powertools-validation/src/main/java/software/amazon/lambda/powertools/validation/ValidationConfig.java
@@ -47,9 +47,15 @@ public class ValidationConfig {
     }
 
     /**
-     * Set the version of the json schema specifications (default is V7)
+     * Set the version of the json schema specifications to use if $schema is not
+     * explicitly specified within the schema (default is V7). If $schema is
+     * explicitly specified within the schema is explicitly specified within the
+     * schema, the validator will use the specified dialect.
      *
      * @param version May be V4, V6, V7, V201909 or V202012
+     * @see <a href=
+     *      "https://json-schema.org/understanding-json-schema/reference/schema#declaring-a-dialect">Declaring
+     *      a Dialect</a>
      */
     public void setSchemaVersion(SpecVersion.VersionFlag version) {
         if (version != jsonSchemaVersion) {

--- a/powertools-validation/src/test/java/software/amazon/lambda/powertools/validation/ValidationUtilsTest.java
+++ b/powertools-validation/src/test/java/software/amazon/lambda/powertools/validation/ValidationUtilsTest.java
@@ -48,7 +48,7 @@ public class ValidationUtilsTest {
         ValidationConfig.get().setSchemaVersion(SpecVersion.VersionFlag.V7);
         JsonSchema jsonSchema = getJsonSchema("classpath:/schema_v7.json", true);
         assertThat(jsonSchema).isNotNull();
-        assertThat(jsonSchema.getCurrentUri()).asString().isEqualTo("http://example.com/product.json");
+        assertThat(jsonSchema.getId()).isEqualTo("http://example.com/product.json");
     }
 
     @Test
@@ -57,7 +57,7 @@ public class ValidationUtilsTest {
         assertThatThrownBy(() -> getJsonSchema("classpath:/schema_v7_ko.json", true))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(
-                        "The schema classpath:/schema_v7_ko.json is not valid, it does not respect the specification /draft-07/schema");
+                        "The schema classpath:/schema_v7_ko.json is not valid, it does not respect the specification /draft-07/schema#");
     }
 
     @Test

--- a/powertools-validation/src/test/resources/schema_v7.json
+++ b/powertools-validation/src/test/resources/schema_v7.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://example.com/product.json",
   "type": "object",
   "title": "Product schema",

--- a/powertools-validation/src/test/resources/schema_v7_ko.json
+++ b/powertools-validation/src/test/resources/schema_v7_ko.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "Product schema",
   "description": "JSON schema to validate Products",


### PR DESCRIPTION
**Issue #, if available:** #1663

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

Upgrades com.networknt:json-schema-validator to 1.4.3.

Note that the validation error messages have changed since 1.0.87.

```json
{
  "validationErrors": [
    {
      "type": "enum",
      "code": "1008",
      "message": "/properties/name/type: does not have a value in the enumeration [array, boolean, integer, null, number, object, string]",
      "instanceLocation": "/properties/name/type",
      "evaluationPath": "/properties/properties/additionalProperties/$ref/properties/type/anyOf/0/$ref/enum",
      "schemaLocation": "http://json-schema.org/draft-07/schema#/definitions/simpleTypes/enum",
      "messageKey": "enum",
      "arguments": [
        "[array, boolean, integer, null, number, object, string]"
      ]
    },
    {
      "type": "type",
      "code": "1029",
      "message": "/properties/name/type: string found, array expected",
      "instanceLocation": "/properties/name/type",
      "evaluationPath": "/properties/properties/additionalProperties/$ref/properties/type/anyOf/1/type",
      "schemaLocation": "http://json-schema.org/draft-07/schema#/properties/type/anyOf/1/type",
      "messageKey": "type",
      "arguments": [
        "string",
        "array"
      ]
    }
  ]
}
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
