### PR TITLE
chore: java 1.8 AL1 is deprecated, fix E2E tests

### DIFF
--- a/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/testutils/Infrastructure.java
+++ b/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/testutils/Infrastructure.java
@@ -513,7 +513,7 @@ public class Infrastructure {
 
         private JavaRuntime mapRuntimeVersion(String environmentVariableName) {
             String javaVersion = System.getenv(environmentVariableName); // must be set in GitHub actions
-            JavaRuntime ret = null;
+            JavaRuntime ret;
             if (javaVersion == null) {
                 throw new IllegalArgumentException(environmentVariableName + " is not set");
             }

--- a/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/testutils/JavaRuntime.java
+++ b/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/testutils/JavaRuntime.java
@@ -17,7 +17,6 @@ package software.amazon.lambda.powertools.testutils;
 import software.amazon.awscdk.services.lambda.Runtime;
 
 public enum JavaRuntime {
-    JAVA8("java8", Runtime.JAVA_8, "1.8"),
     JAVA8AL2("java8.al2", Runtime.JAVA_8_CORRETTO, "1.8"),
     JAVA11("java11", Runtime.JAVA_11, "11"),
     JAVA17("java17", Runtime.JAVA_17, "17"),


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

- removing 1.8 AL1 from E2E tests as it is deprecated

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
