### PR TITLE
chore: deprecate java1.8 al1

### DIFF
--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -187,7 +187,7 @@ You can also override log level by setting **`POWERTOOLS_LOG_LEVEL`** env var. H
             Type: AWS::Serverless::Function
             Properties:
             ...
-            Runtime: java8
+            Runtime: java11
             Environment:
                 Variables:
                     POWERTOOLS_LOG_LEVEL: DEBUG
@@ -590,7 +590,7 @@ via `samplingRate` attribute on annotation.
             Type: AWS::Serverless::Function
             Properties:
             ...
-            Runtime: java8
+            Runtime: java11
             Environment:
                 Variables:
                     POWERTOOLS_LOGGER_SAMPLE_RATE: 0.5

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -179,7 +179,7 @@ Setting | Description | Environment variable | Constructor parameter
             Type: AWS::Serverless::Function
             Properties:
             ...
-            Runtime: java8
+            Runtime: java11
             Environment:
                 Variables:
                     POWERTOOLS_SERVICE_NAME: payment

--- a/docs/core/tracing.md
+++ b/docs/core/tracing.md
@@ -164,7 +164,7 @@ Before your use this utility, your AWS Lambda function [must have permissions](h
             Type: AWS::Serverless::Function
             Properties:
             ...
-            Runtime: java8
+            Runtime: java11
     
             Tracing: Active
             Environment:
@@ -250,7 +250,7 @@ different supported `captureMode` to record response, exception or both.
             Type: AWS::Serverless::Function
             Properties:
             ...
-            Runtime: java8
+            Runtime: java11
     
             Tracing: Active
             Environment:

--- a/examples/powertools-examples-core/gradle/template.yaml
+++ b/examples/powertools-examples-core/gradle/template.yaml
@@ -26,7 +26,7 @@ Resources:
     Properties:
       CodeUri: .
       Handler: helloworld.App::handleRequest
-      Runtime: java8
+      Runtime: java8.al2
       MemorySize: 512
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
@@ -43,7 +43,7 @@ Resources:
     Properties:
       CodeUri: .
       Handler: helloworld.AppStream::handleRequest
-      Runtime: java8
+      Runtime: java8.al2
       MemorySize: 512
       Tracing: Active
       Environment:

--- a/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/testutils/Infrastructure.java
+++ b/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/testutils/Infrastructure.java
@@ -513,7 +513,7 @@ public class Infrastructure {
 
         private JavaRuntime mapRuntimeVersion(String environmentVariableName) {
             String javaVersion = System.getenv(environmentVariableName); // must be set in GitHub actions
-            JavaRuntime ret = null;
+            JavaRuntime ret;
             if (javaVersion == null) {
                 throw new IllegalArgumentException(environmentVariableName + " is not set");
             }

--- a/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/testutils/JavaRuntime.java
+++ b/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/testutils/JavaRuntime.java
@@ -17,7 +17,6 @@ package software.amazon.lambda.powertools.testutils;
 import software.amazon.awscdk.services.lambda.Runtime;
 
 public enum JavaRuntime {
-    JAVA8("java8", Runtime.JAVA_8, "1.8"),
     JAVA8AL2("java8.al2", Runtime.JAVA_8_CORRETTO, "1.8"),
     JAVA11("java11", Runtime.JAVA_11, "11"),
     JAVA17("java17", Runtime.JAVA_17, "17"),


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

- Remove java8 from sam examples: `Error: Building functions with java8 is no longer supported`

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
