### PR TITLE
docs: add roadmap page and include roadmap for 2025

### DIFF
--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -6,7 +6,7 @@ description: Frequently Asked Questions
 
 ## How can I use Powertools for AWS Lambda (Java) with Lombok?
 
-Poweretools uses `aspectj-maven-plugin` to compile-time weave (CTW) aspects into the project. In case you want to use `Lombok` or other compile-time preprocessor for your project, it is required to change `aspectj-maven-plugin` configuration to enable in-place weaving feature. Otherwise the plugin will ignore changes introduced by `Lombok` and will use `.java` files as a source. 
+Powertools uses `aspectj-maven-plugin` to compile-time weave (CTW) aspects into the project. In case you want to use `Lombok` or other compile-time preprocessor for your project, it is required to change `aspectj-maven-plugin` configuration to enable in-place weaving feature. Otherwise, the plugin will ignore changes introduced by `Lombok` and will use `.java` files as a source. 
 
 To enable in-place weaving feature you need to use following `aspectj-maven-plugin` configuration:
 
@@ -29,7 +29,7 @@ To enable in-place weaving feature you need to use following `aspectj-maven-plug
 
 ## How can I use Powertools for AWS Lambda (Java) with Kotlin projects?
 
-Poweretools uses `aspectj-maven-plugin` to compile-time weave (CTW) aspects into the project. When using it with Kotlin projects, it is required to `forceAjcCompile`. 
+Powertools uses `aspectj-maven-plugin` to compile-time weave (CTW) aspects into the project. When using it with Kotlin projects, it is required to `forceAjcCompile`. 
 No explicit configuration should be required for gradle projects. 
 
 To enable `forceAjcCompile` you need to use following `aspectj-maven-plugin` configuration:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,139 @@
+---
+title: Roadmap
+description: Public roadmap for Powertools for AWS Lambda (Java)
+---
+
+## Overview
+
+Our public roadmap outlines the high level direction we are working towards. We update this document when our priorities change: security and stability are our top priority.
+
+### Key areas
+
+Security and operational excellence take precedence above all else. This means bug fixing, stability, customer's support, and internal compliance may delay one or more key areas below.
+
+!!! info "We may choose to re-prioritize or defer items based on customer feedback, security, and operational impacts, and business value."
+
+#### Release Security (p0)
+
+Our top priority is to establish the processes and infrastructure needed for a fully automated and secure end-to-end release process of new versions to Maven Central.
+
+- [ ] Implement GitHub workflows and create infrastructure to release to Maven Central
+- [ ] Implement end-to-end tests
+- [ ] Implement [OpenSSF Scorecard](https://openssf.org/projects/scorecard/){target="\_blank"}
+
+#### `v2` Release: Consistency and Ecosystem (p1)
+
+As part of a new major version `v2` release, we prioritize the Java project's consistency of core utilities (Logging, Metrics, Tracing) with the other runtimes (Python, TypeScript, .NET). Additionally, we will focus on integrating the library with popular technologies and frameworks from the Java and AWS ecosystem. Particularly, we aim at leveraging new techniques to allow customers to reduce Lambda cold-start time. The `v2` release will also drop support for Java 8 moving to Java 11 as the baseline.
+
+##### Core Utilities
+
+- [ ] [Review public interfaces and reduce public API surface area](https://github.com/aws-powertools/powertools-lambda-java/issues/1283){target="\_blank"}
+- [ ] [Release Logging `v2` module](https://github.com/aws-powertools/powertools-lambda-java/issues/965){target="\_blank"}
+- [ ] [Support high resolution metrics](https://github.com/aws-powertools/powertools-lambda-java/issues/1041){target="\_blank"}
+
+##### Ecosystem
+
+- [ ] [Add GraalVM support](https://github.com/aws-powertools/powertools-lambda-java/issues/764){target="\_blank"}
+- [ ] [Implement priming using CRaC to improve AWS Snapstart support](https://github.com/aws-powertools/powertools-lambda-java/issues/1588){target="\_blank"}
+- [ ] [Add integrations with popular Java frameworks such as Micronaut, Spring Cloud Function, or Quarkus](https://github.com/aws-powertools/powertools-lambda-java/issues/1701){target="\_blank"}
+
+##### Other
+
+- [ ] [Validation module integration with HTTP requests](https://github.com/aws-powertools/powertools-lambda-java/issues/1298){target="\_blank"}
+- [ ] [Support validation module from within the batch module](https://github.com/aws-powertools/powertools-lambda-java/issues/1496){target="\_blank"}
+- [ ] Documentation: Review and improve documentation to be consistent with other runtimes
+
+#### Feature Parity (p2)
+
+If priorities `p0` and `p1` are addressed, we will also focus on feature parity of non-core utilities. This allows customers to achieve better standardization of their development processes across different Powertools runtimes.
+
+- [ ] [Re-evaluate if there is a need for adding a lightweight customer Powertools event handler](https://github.com/aws-powertools/powertools-lambda-java/issues/1103){target="\_blank"}
+- [ ] [Add Feature Flags module](https://github.com/aws-powertools/powertools-lambda-java/issues/1086){target="\_blank"}
+- [ ] [Add S3 Streaming module](https://github.com/aws-powertools/powertools-lambda-java/issues/1085){target="\_blank"}
+- [ ] Add support for Data Masking during JSON serialization
+
+### Missing something?
+
+You can help us prioritize by [upvoting existing feature requests](https://github.com/aws-powertools/powertools-lambda-java/issues?q=is%3Aissue%20state%3Aopen%20label%3Aenhancement){target="\_blank"},
+leaving a comment on what use cases it could unblock for you, and by joining our discussions on Discord.
+
+[![Join our Discord](https://dcbadge.vercel.app/api/server/B8zZKbbyET)](https://discord.gg/B8zZKbbyET){target="\_blank"}
+
+### Roadmap status definition
+
+<center>
+```mermaid
+graph LR
+    Ideas --> Backlog --> Work["Working on it"] --> Merged["Coming soon"] --> Shipped
+```
+<i>Visual representation</i>
+</center>
+
+Within our [public board](https://github.com/orgs/aws-powertools/projects/4/){target="\_blank"}, you'll see the following values in the `Status` column:
+
+- **Ideas**. Incoming and existing feature requests that are not being actively considered yet. These will be reviewed
+  when bandwidth permits.
+- **Backlog**. Accepted feature requests or enhancements that we want to work on.
+- **Working on it**. Features or enhancements we're currently either researching or implementing it.
+- **Coming soon**. Any feature, enhancement, or bug fixes that have been merged and are coming in the next release.
+- **Shipped**. Features or enhancements that are now available in the most recent release.
+
+> Tasks or issues with empty `Status` will be categorized in upcoming review cycles.
+
+### Process
+
+<center>
+```mermaid
+graph LR
+    PFR[Feature request] --> Triage{Need RFC?}
+    Triage --> |Complex/major change or new utility?| RFC[Ask or write RFC] --> Approval{Approved?}
+    Triage --> |Minor feature or enhancement?| NoRFC[No RFC required] --> Approval
+    Approval --> |Yes| Backlog
+    Approval --> |No | Reject["Inform next steps"]
+    Backlog --> |Prioritized| Implementation
+    Backlog --> |Defer| WelcomeContributions["help-wanted label"]
+```
+<i>Visual representation</i>
+</center>
+
+Our end-to-end mechanism follows four major steps:
+
+- **Feature Request**. Ideas start with a [feature request](https://github.com/aws-powertools/powertools-lambda-java/issues/new?template=feature_request.md){target="\_blank"} to outline their use case at a high level. For complex use cases, maintainers might ask for/write a
+  RFC.
+  - Maintainers review requests based on [project tenets](index.md#tenets){target="\_blank"}, customers reaction (👍),
+    and use cases.
+- **Request-for-comments (RFC)**. Design proposals use
+  our [RFC template](https://github.com/aws-powertools/powertools-lambda-java/issues/new?q=is%3Aissue+state%3Aopen+label%3Aenhancement&template=rfc.md){target="\_blank"} to describe its implementation, challenges, developer experience, dependencies, and alternative solutions.
+  - This helps refine the initial idea with community feedback before a decision is made.
+- **Decision**. After carefully reviewing and discussing them, maintainers make a final decision on whether to start
+  implementation, defer or reject it, and update everyone with the next steps.
+- **Implementation**. For approved features, maintainers give priority to the original authors for implementation unless
+  it is a sensitive task that is best handled by maintainers.
+
+!!! info "See [Maintainers](./processes/maintainers.md){target="\_blank"} document to understand how we triage issues and pull requests, labels and governance."
+
+### Disclaimer
+
+The Powertools for AWS Lambda (Java) team values feedback and guidance from its community of users, although final
+decisions on inclusion into the project will be made by AWS.
+
+We determine the high-level direction for our open roadmap based on customer feedback and popularity (👍🏽 and comments),
+security and operational impacts, and business value. Where features don’t meet our goals and longer-term strategy, we
+will communicate that clearly and openly as quickly as possible with an explanation of why the decision was made.
+
+### FAQs
+
+**Q: Why did you build this?**
+
+A: We know that our customers are making decisions and plans based on what we are developing, and we want to provide our
+customers the insights they need to plan.
+
+**Q: Why are there no dates on your roadmap?**
+
+A: Because job zero is security and operational stability, we can't provide specific target dates for features. The
+roadmap is subject to change at any time, and roadmap issues in this repository do not guarantee a feature will be
+launched as proposed.
+
+**Q: How can I provide feedback or ask for more information?**
+
+A: For existing features, you can directly comment on issues. For anything else, please open an issue.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,7 +35,7 @@ As part of a new major version `v2` release, we prioritize the Java project's co
 
 - [ ] [Add GraalVM support](https://github.com/aws-powertools/powertools-lambda-java/issues/764){target="\_blank"}
 - [ ] [Implement priming using CRaC to improve AWS Snapstart support](https://github.com/aws-powertools/powertools-lambda-java/issues/1588){target="\_blank"}
-- [ ] [Add integrations with popular Java frameworks such as Micronaut, Spring Cloud Function, or Quarkus](https://github.com/aws-powertools/powertools-lambda-java/issues/1701){target="\_blank"}
+- [ ] [Evaluate integration with popular Java frameworks such as Micronaut, Spring Cloud Function, or Quarkus](https://github.com/aws-powertools/powertools-lambda-java/issues/1701){target="\_blank"}
 
 ##### Other
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ nav:
   - Changelog: changelog.md
   - Workshop 🆕: https://s12d.com/powertools-for-aws-lambda-workshop" target="_blank
   - FAQs: FAQs.md
+  - Roadmap: roadmap.md
   - Core utilities:
       - core/logging.md
       - core/tracing.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,8 +62,10 @@ markdown_extensions:
       alternate_style: true
   - pymdownx.details
   - pymdownx.snippets:
-      base_path: '.'
+      base_path: "."
       check_paths: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid


### PR DESCRIPTION
**Issue #, if available:** https://github.com/aws-powertools/powertools-lambda-java/issues/1761

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [N/A] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Screenshot of rendered documentation:
<img width="1205" alt="Screenshot 2025-02-11 at 14 11 22" src="https://github.com/user-attachments/assets/b95d4833-ee63-4f61-8469-e2398cadadb9" />

