### PR TITLE
build(deps): Fix Jackson version to max allowed by JSII

### DIFF
--- a/examples/powertools-examples-core/cdk/infra/pom.xml
+++ b/examples/powertools-examples-core/cdk/infra/pom.xml
@@ -7,8 +7,9 @@
     <version>1.18.0</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cdk.version>2.130.0</cdk.version>
+        <cdk.version>2.178.1</cdk.version>
         <constructs.version>[10.0.0,11.0.0)</constructs.version>
+        <jackson.version>2.14.0</jackson.version>
         <junit.version>5.10.0</junit.version>
     </properties>
     <build>
@@ -41,6 +42,13 @@
         </plugins>
     </build>
     <dependencies>
+        <!-- Transitive Dep -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        
         <!-- AWS Cloud Development Kit -->
         <dependency>
             <groupId>software.amazon.awscdk</groupId>


### PR DESCRIPTION
**Issue #, if available:** 

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

Pin JSII's jackson-databind version to 2.14

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
