### PR TITLE
docs: Correct XML formatting for Maven configuration in Large Messages utility docs

### DIFF
--- a/docs/utilities/large_messages.md
+++ b/docs/utilities/large_messages.md
@@ -105,44 +105,44 @@ Depending on your version of Java (either Java 1.8 or 11+), the configuration sl
 === "Maven Java 11+"
 ```xml hl_lines="3-7 16 18 24-27"
 <dependencies>
-...
-<dependency>
-<groupId>software.amazon.lambda</groupId>
-<artifactId>powertools-large-messages</artifactId>
-<version>{{ powertools.version }}</version>
-</dependency>
-...
+    ...
+    <dependency>
+        <groupId>software.amazon.lambda</groupId>
+        <artifactId>powertools-large-messages</artifactId>
+        <version>{{ powertools.version }}</version>
+    </dependency>
+    ...
 </dependencies>
 ...
 <!-- configure the aspectj-maven-plugin to compile-time weave (CTW) the aws-lambda-powertools-java aspects into your project -->
 <build>
-<plugins>
-...
-<plugin>
-<groupId>dev.aspectj</groupId>
-<artifactId>aspectj-maven-plugin</artifactId>
-<version>1.13.1</version>
-<configuration>
-<source>11</source> <!-- or higher -->
-<target>11</target> <!-- or higher -->
-<complianceLevel>11</complianceLevel> <!-- or higher -->
-<aspectLibraries>
-<aspectLibrary>
-<groupId>software.amazon.lambda</groupId>
-<artifactId>powertools-large-messages</artifactId>
-</aspectLibrary>
-</aspectLibraries>
-</configuration>
-<executions>
-<execution>
-<goals>
-<goal>compile</goal>
-</goals>
-</execution>
-</executions>
-</plugin>
-...
-</plugins>
+    <plugins>
+        ...
+        <plugin>
+            <groupId>dev.aspectj</groupId>
+            <artifactId>aspectj-maven-plugin</artifactId>
+            <version>1.13.1</version>
+            <configuration>
+                <source>11</source> <!-- or higher -->
+                <target>11</target> <!-- or higher -->
+                <complianceLevel>11</complianceLevel> <!-- or higher -->
+                <aspectLibraries>
+                    <aspectLibrary>
+                        <groupId>software.amazon.lambda</groupId>
+                        <artifactId>powertools-large-messages</artifactId>
+                    </aspectLibrary>
+                </aspectLibraries>
+            </configuration>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>compile</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+        ...
+    </plugins>
 </build>
 ```
 


### PR DESCRIPTION
Fix indentation in large messages docs for aspectj-maven-plugin

**Issue #, if available:**

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

While reading the docs for the large messages utility I noticed the XML formatting was off for the maven configuration. The formatting is missing indentation. This PR tries to fix that.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
