### PR TITLE
feat(idempotency): Add response hook feature

### DIFF
--- a/examples/powertools-examples-idempotency/src/main/java/helloworld/App.java
+++ b/examples/powertools-examples-idempotency/src/main/java/helloworld/App.java
@@ -73,7 +73,7 @@ public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatew
     }
 
     /**
-     * This is our Lambda event handler. It accepts HTTP POST requests from API gateway and returns the contents of the
+     * This is your Lambda event handler. It accepts HTTP POST requests from API gateway and returns the contents of the
      * given URL. Requests are made idempotent
      * by the idempotency library, and results are cached for the default 1h expiry time.
      * <p>

--- a/powertools-idempotency/powertools-idempotency-core/src/main/java/software/amazon/lambda/powertools/idempotency/internal/IdempotencyHandler.java
+++ b/powertools-idempotency/powertools-idempotency-core/src/main/java/software/amazon/lambda/powertools/idempotency/internal/IdempotencyHandler.java
@@ -187,8 +187,7 @@ public class IdempotencyHandler {
             }
 
             if (responseHook != null) {
-                LOG.debug(
-                        "Found user-defined idempotent response hook. Calling with response data and persistence store data record.");
+                LOG.debug("Applying user-defined response hook to idempotency data before returning.");
                 return responseHook.apply(responseData, record);
             }
 


### PR DESCRIPTION
**Issue #, if available:** https://github.com/aws-powertools/powertools-lambda-java/issues/1780

## Description of changes:
This PR adds the possibility of creating a response hook in the Idempotency configuration that will be applied on all idempotent responses before returning. 

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
