### PR TITLE
feat(idempotency): Add support for ReturnValuesOnConditionCheckFailure in Idempotency.

### DIFF
--- a/powertools-idempotency/powertools-idempotency-core/src/main/java/software/amazon/lambda/powertools/idempotency/exceptions/IdempotencyItemAlreadyExistsException.java
+++ b/powertools-idempotency/powertools-idempotency-core/src/main/java/software/amazon/lambda/powertools/idempotency/exceptions/IdempotencyItemAlreadyExistsException.java
@@ -14,11 +14,17 @@
 
 package software.amazon.lambda.powertools.idempotency.exceptions;
 
+import java.util.Optional;
+
+import software.amazon.lambda.powertools.idempotency.persistence.DataRecord;
+
 /**
  * Exception thrown when trying to store an item which already exists.
  */
 public class IdempotencyItemAlreadyExistsException extends RuntimeException {
     private static final long serialVersionUID = 9027152772149436500L;
+    // transient because we don't want to accidentally dump any payloads in logs / stack traces
+    private transient Optional<DataRecord> dr = Optional.empty();
 
     public IdempotencyItemAlreadyExistsException() {
         super();
@@ -26,5 +32,14 @@ public class IdempotencyItemAlreadyExistsException extends RuntimeException {
 
     public IdempotencyItemAlreadyExistsException(String msg, Throwable e) {
         super(msg, e);
+    }
+
+    public IdempotencyItemAlreadyExistsException(String msg, Throwable e, DataRecord dr) {
+        super(msg, e);
+        this.dr = Optional.ofNullable(dr);
+    }
+
+    public Optional<DataRecord> getDataRecord() {
+        return dr;
     }
 }

--- a/powertools-idempotency/powertools-idempotency-core/src/main/java/software/amazon/lambda/powertools/idempotency/persistence/DataRecord.java
+++ b/powertools-idempotency/powertools-idempotency-core/src/main/java/software/amazon/lambda/powertools/idempotency/persistence/DataRecord.java
@@ -53,7 +53,7 @@ public class DataRecord {
     private final OptionalLong inProgressExpiryTimestamp;
 
     public DataRecord(String idempotencyKey, Status status, long expiryTimestamp, String responseData,
-                      String payloadHash) {
+            String payloadHash) {
         this.idempotencyKey = idempotencyKey;
         this.status = status.toString();
         this.expiryTimestamp = expiryTimestamp;
@@ -63,7 +63,7 @@ public class DataRecord {
     }
 
     public DataRecord(String idempotencyKey, Status status, long expiryTimestamp, String responseData,
-                      String payloadHash, OptionalLong inProgressExpiryTimestamp) {
+            String payloadHash, OptionalLong inProgressExpiryTimestamp) {
         this.idempotencyKey = idempotencyKey;
         this.status = status.toString();
         this.expiryTimestamp = expiryTimestamp;
@@ -131,13 +131,22 @@ public class DataRecord {
         return Objects.hash(idempotencyKey, status, expiryTimestamp, responseData, payloadHash);
     }
 
+    @Override
+    public String toString() {
+        return "DataRecord{" +
+                "idempotencyKey='" + idempotencyKey + '\'' +
+                ", status='" + status + '\'' +
+                ", expiryTimestamp=" + expiryTimestamp +
+                ", payloadHash='" + payloadHash + '\'' +
+                '}';
+    }
 
     /**
      * Status of the record:
      * <ul>
-     *  <li>INPROGRESS: record initialized when function starts</li>
-     *  <li>COMPLETED: record updated with the result of the function when it ends</li>
-     *  <li>EXPIRED: record expired, idempotency will not happen</li>
+     * <li>INPROGRESS: record initialized when function starts</li>
+     * <li>COMPLETED: record updated with the result of the function when it ends</li>
+     * <li>EXPIRED: record expired, idempotency will not happen</li>
      * </ul>
      */
     public enum Status {

--- a/powertools-idempotency/powertools-idempotency-dynamodb/src/test/java/software/amazon/lambda/powertools/idempotency/persistence/dynamodb/DynamoDBConfig.java
+++ b/powertools-idempotency/powertools-idempotency-dynamodb/src/test/java/software/amazon/lambda/powertools/idempotency/persistence/dynamodb/DynamoDBConfig.java
@@ -12,15 +12,18 @@
  *
  */
 
-package software.amazon.lambda.powertools.idempotency.dynamodb;
+package software.amazon.lambda.powertools.idempotency.persistence.dynamodb;
 
-import com.amazonaws.services.dynamodbv2.local.main.ServerRunner;
-import com.amazonaws.services.dynamodbv2.local.server.DynamoDBProxyServer;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.URI;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+
+import com.amazonaws.services.dynamodbv2.local.main.ServerRunner;
+import com.amazonaws.services.dynamodbv2.local.server.DynamoDBProxyServer;
+
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
@@ -66,13 +69,12 @@ public class DynamoDBConfig {
                 .tableName(TABLE_NAME)
                 .keySchema(KeySchemaElement.builder().keyType(KeyType.HASH).attributeName("id").build())
                 .attributeDefinitions(
-                        AttributeDefinition.builder().attributeName("id").attributeType(ScalarAttributeType.S).build()
-                )
+                        AttributeDefinition.builder().attributeName("id").attributeType(ScalarAttributeType.S).build())
                 .billingMode(BillingMode.PAY_PER_REQUEST)
                 .build());
 
-        DescribeTableResponse response =
-                client.describeTable(DescribeTableRequest.builder().tableName(TABLE_NAME).build());
+        DescribeTableResponse response = client
+                .describeTable(DescribeTableRequest.builder().tableName(TABLE_NAME).build());
         if (response == null) {
             throw new RuntimeException("Table was not created within expected time");
         }

--- a/powertools-idempotency/powertools-idempotency-dynamodb/src/test/java/software/amazon/lambda/powertools/idempotency/persistence/dynamodb/IdempotencyTest.java
+++ b/powertools-idempotency/powertools-idempotency-dynamodb/src/test/java/software/amazon/lambda/powertools/idempotency/persistence/dynamodb/IdempotencyTest.java
@@ -12,20 +12,21 @@
  *
  */
 
-package software.amazon.lambda.powertools.idempotency.dynamodb;
-
+package software.amazon.lambda.powertools.idempotency.persistence.dynamodb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.amazonaws.services.lambda.runtime.tests.EventLoader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.amazonaws.services.lambda.runtime.tests.EventLoader;
+
 import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
-import software.amazon.lambda.powertools.idempotency.dynamodb.handlers.IdempotencyFunction;
+import software.amazon.lambda.powertools.idempotency.persistence.dynamodb.handlers.IdempotencyFunction;
 
 public class IdempotencyTest extends DynamoDBConfig {
 
@@ -41,14 +42,14 @@ public class IdempotencyTest extends DynamoDBConfig {
     public void endToEndTest() {
         IdempotencyFunction function = new IdempotencyFunction(client);
 
-        APIGatewayProxyResponseEvent response =
-                function.handleRequest(EventLoader.loadApiGatewayRestEvent("apigw_event2.json"), context);
+        APIGatewayProxyResponseEvent response = function
+                .handleRequest(EventLoader.loadApiGatewayRestEvent("apigw_event2.json"), context);
         assertThat(function.handlerExecuted).isTrue();
 
         function.handlerExecuted = false;
 
-        APIGatewayProxyResponseEvent response2 =
-                function.handleRequest(EventLoader.loadApiGatewayRestEvent("apigw_event2.json"), context);
+        APIGatewayProxyResponseEvent response2 = function
+                .handleRequest(EventLoader.loadApiGatewayRestEvent("apigw_event2.json"), context);
         assertThat(function.handlerExecuted).isFalse();
 
         assertThat(response).isEqualTo(response2);

--- a/powertools-idempotency/powertools-idempotency-dynamodb/src/test/java/software/amazon/lambda/powertools/idempotency/persistence/dynamodb/handlers/IdempotencyFunction.java
+++ b/powertools-idempotency/powertools-idempotency-dynamodb/src/test/java/software/amazon/lambda/powertools/idempotency/persistence/dynamodb/handlers/IdempotencyFunction.java
@@ -12,14 +12,16 @@
  *
  */
 
-package software.amazon.lambda.powertools.idempotency.dynamodb.handlers;
+package software.amazon.lambda.powertools.idempotency.persistence.dynamodb.handlers;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import java.util.HashMap;
-import java.util.Map;
+
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.lambda.powertools.idempotency.Idempotency;
 import software.amazon.lambda.powertools.idempotency.IdempotencyConfig;
@@ -32,15 +34,15 @@ public class IdempotencyFunction implements RequestHandler<APIGatewayProxyReques
     public IdempotencyFunction(DynamoDbClient client) {
         // we need to initialize idempotency configuration before the handleRequest method is called
         Idempotency.config().withConfig(
-                        IdempotencyConfig.builder()
-                                .withEventKeyJMESPath("powertools_json(body).address")
-                                .build())
+                IdempotencyConfig.builder()
+                        .withEventKeyJMESPath("powertools_json(body).address")
+                        .build())
                 .withPersistenceStore(
                         DynamoDBPersistenceStore.builder()
                                 .withTableName("idempotency_table")
                                 .withDynamoDbClient(client)
-                                .build()
-                ).configure();
+                                .build())
+                .configure();
     }
 
     @Idempotent
@@ -56,9 +58,9 @@ public class IdempotencyFunction implements RequestHandler<APIGatewayProxyReques
         APIGatewayProxyResponseEvent response = new APIGatewayProxyResponseEvent()
                 .withHeaders(headers);
 
-            return response
-                    .withStatusCode(200)
-                    .withBody("{ \"message\": \"hello world\"}");
+        return response
+                .withStatusCode(200)
+                .withBody("{ \"message\": \"hello world\"}");
 
     }
 }


### PR DESCRIPTION
**Issue #, if available:** https://github.com/aws-powertools/powertools-lambda-java/issues/1784

## Description of changes:

This feature avoids redundant DynamoDB calls in the Idempotency utility by making use of the `ReturnValuesOnConditionCheckFailure` option in the AWS SDK.

Instead of re-fetching a data record from the persistence store when a `IdempotencyItemAlreadyExistsException` is thrown, it attaches the offending data record to the exception so that it can be directly returned to the caller without making another DynamoDB call. 

Note: In addition to unit tests, I ran E2E tests as well. Until E2E tests are restored in GitHub workflows, here is the output from running in my AWS account.

```
❯ mvn -Pe2e -B verify --file powertools-e2e-tests/pom.xml -Dtest="IdempotencyE2ET.java"
...
20:49:11.010 [main] INFO  software.amazon.lambda.powertools.testutils.Infrastructure - Uploading asset 839b70aab886d0655a55d0cd5db0219df16a020b1bdbcf192a3cfde01ca214d7.jar to cdk-hnb659fds-assets-********-eu-west-1
20:49:15.632 [main] INFO  software.amazon.lambda.powertools.testutils.Infrastructure - Deploying 'IdempotencyE2ET-c8f8877bbdc9' on account ********
20:50:16.714 [main] INFO  software.amazon.lambda.powertools.testutils.Infrastructure - Stack IdempotencyE2ET-c8f8877bbdc9 successfully deployed
20:50:33.978 [main] INFO  software.amazon.lambda.powertools.testutils.Infrastructure - Deleting 'IdempotencyE2ET-c8f8877bbdc9' on account ********
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 94.41 s -- in software.amazon.lambda.powertools.IdempotencyE2ET
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
