### PR TITLE
fix(logging): Prevent accidental overwriting of reserved keys via structured arguments

### DIFF
--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -640,6 +640,9 @@ To append additional keys in your logs, you can use the `StructuredArguments` cl
             }
         ```
 
+???+ warning "Warning"
+    If the key name of your structured argument matches any of the [standard structured keys](#standard-structured-keys) or any of the [additional structured keys](#additional-structured-keys) the whole argument will be ignored. This is to protect you from accidentally overwriting reserved keys such as the log level or Lambda context information.
+    
 **Using MDC**
 
 Mapped Diagnostic Context (MDC) is essentially a Key-Value store. It is supported by the [SLF4J API](https://www.slf4j.org/manual.html#mdc){target="_blank"},

--- a/powertools-logging/powertools-logging-log4j/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/PowertoolsResolver.java
+++ b/powertools-logging/powertools-logging-log4j/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/PowertoolsResolver.java
@@ -48,7 +48,8 @@ import software.amazon.lambda.powertools.logging.internal.PowertoolsLoggedFields
  */
 final class PowertoolsResolver implements EventResolver {
     private static final Set<String> RESERVED_LOG_KEYS = Stream
-            .concat(PowertoolsLoggedFields.stringValues().stream(), List.of("message", "level", "timestamp").stream())
+            .concat(PowertoolsLoggedFields.stringValues().stream(),
+                    List.of("message", "level", "timestamp", "error").stream())
             .collect(Collectors.toSet());
 
     private static final EventResolver COLD_START_RESOLVER = new EventResolver() {

--- a/powertools-logging/powertools-logging-log4j/src/test/java/org/apache/logging/log4j/layout/template/json/resolver/PowertoolsResolverArgumentsTest.java
+++ b/powertools-logging/powertools-logging-log4j/src/test/java/org/apache/logging/log4j/layout/template/json/resolver/PowertoolsResolverArgumentsTest.java
@@ -35,6 +35,8 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.slf4j.MDC;
+
+import software.amazon.lambda.powertools.logging.internal.PowertoolsLoggedFields;
 import software.amazon.lambda.powertools.logging.internal.handler.PowertoolsArguments;
 
 @Order(2)
@@ -83,9 +85,14 @@ class PowertoolsResolverArgumentsTest {
         // THEN
         File logFile = new File("target/logfile.json");
         assertThat(contentOf(logFile))
-                .contains("\"input\":{\"awsRegion\":\"eu-west-1\",\"body\":\"plop\",\"eventSource\":\"eb\",\"messageAttributes\":{\"keyAttribute\":{\"stringListValues\":[\"val1\",\"val2\",\"val3\"]}},\"messageId\":\"1212abcd\"}")
+                .contains(
+                        "\"input\":{\"awsRegion\":\"eu-west-1\",\"body\":\"plop\",\"eventSource\":\"eb\",\"messageAttributes\":{\"keyAttribute\":{\"stringListValues\":[\"val1\",\"val2\",\"val3\"]}},\"messageId\":\"1212abcd\"}")
                 .contains("\"message\":\"1212abcd\"")
                 .contains("\"message\":\"Message body = plop and id = \\\"1212abcd\\\"\"");
+        // Reserved keys should be ignored
+        PowertoolsLoggedFields.stringValues().stream().forEach(reservedKey -> {
+            assertThat(contentOf(logFile)).doesNotContain("\"" + reservedKey + "\":\"shouldBeIgnored\"");
+        });
     }
 
     @Test
@@ -107,9 +114,15 @@ class PowertoolsResolverArgumentsTest {
         // THEN
         File logFile = new File("target/logfile.json");
         assertThat(contentOf(logFile))
-                .contains("\"input\":{\"awsRegion\":\"eu-west-1\",\"body\":\"plop\",\"eventSource\":\"eb\",\"messageAttributes\":{\"keyAttribute\":{\"stringListValues\":[\"val1\",\"val2\",\"val3\"]}},\"messageId\":\"1212abcd\"}")
+                .contains(
+                        "\"input\":{\"awsRegion\":\"eu-west-1\",\"body\":\"plop\",\"eventSource\":\"eb\",\"messageAttributes\":{\"keyAttribute\":{\"stringListValues\":[\"val1\",\"val2\",\"val3\"]}},\"messageId\":\"1212abcd\"}")
                 .contains("\"message\":\"1212abcd\"")
                 .contains("\"message\":\"Message body = plop and id = \\\"1212abcd\\\"\"");
+
+        // Reserved keys should be ignored
+        PowertoolsLoggedFields.stringValues().stream().forEach(reservedKey -> {
+            assertThat(contentOf(logFile)).doesNotContain("\"" + reservedKey + "\":\"shouldBeIgnored\"");
+        });
     }
 
     private void setupContext() {

--- a/powertools-logging/powertools-logging-logback/src/main/java/software/amazon/lambda/powertools/logging/logback/JsonUtils.java
+++ b/powertools-logging/powertools-logging-logback/src/main/java/software/amazon/lambda/powertools/logging/logback/JsonUtils.java
@@ -36,7 +36,8 @@ import software.amazon.lambda.powertools.logging.internal.PowertoolsLoggedFields
  */
 final class JsonUtils {
     private static final Set<String> RESERVED_LOG_KEYS = Stream
-            .concat(PowertoolsLoggedFields.stringValues().stream(), List.of("message", "level", "timestamp").stream())
+            .concat(PowertoolsLoggedFields.stringValues().stream(),
+                    List.of("message", "level", "timestamp", "error").stream())
             .collect(Collectors.toSet());
 
     private JsonUtils() {

--- a/powertools-logging/powertools-logging-logback/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaJsonEncoderTest.java
+++ b/powertools-logging/powertools-logging-logback/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaJsonEncoderTest.java
@@ -29,6 +29,8 @@ import ch.qos.logback.classic.spi.LoggingEvent;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.JSONPObject;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -126,6 +128,10 @@ class LambdaJsonEncoderTest {
                 .contains("\"input\":{\"awsRegion\":\"eu-west-1\",\"body\":\"plop\",\"eventSource\":\"eb\",\"messageAttributes\":{\"keyAttribute\":{\"stringListValues\":[\"val1\",\"val2\",\"val3\"]}},\"messageId\":\"1212abcd\"}")
                 .contains("\"message\":\"1212abcd\"")
                 .contains("\"message\":\"Message body = plop and id = \"1212abcd\"\"");
+        // Reserved keys should be ignored
+        PowertoolsLoggedFields.stringValues().stream().forEach(reservedKey -> {
+            assertThat(contentOf(logFile)).doesNotContain("\"" + reservedKey + "\":\"shouldBeIgnored\"");
+        });
     }
 
     @Test
@@ -150,6 +156,10 @@ class LambdaJsonEncoderTest {
                 .contains("\"input\":{\"awsRegion\":\"eu-west-1\",\"body\":\"plop\",\"eventSource\":\"eb\",\"messageAttributes\":{\"keyAttribute\":{\"stringListValues\":[\"val1\",\"val2\",\"val3\"]}},\"messageId\":\"1212abcd\"}")
                 .contains("\"message\":\"1212abcd\"")
                 .contains("\"message\":\"Message body = plop and id = \"1212abcd\"\"");
+        // Reserved keys should be ignored
+        PowertoolsLoggedFields.stringValues().stream().forEach(reservedKey -> {
+            assertThat(contentOf(logFile)).doesNotContain("\"" + reservedKey + "\":\"shouldBeIgnored\"");
+        });
     }
 
     private final LoggingEvent loggingEvent = new LoggingEvent("fqcn", logger, Level.INFO, "message", null, null);

--- a/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/argument/ArrayArgument.java
+++ b/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/argument/ArrayArgument.java
@@ -15,6 +15,8 @@
 package software.amazon.lambda.powertools.logging.argument;
 
 import java.util.Objects;
+import java.util.Set;
+
 import software.amazon.lambda.powertools.logging.internal.JsonSerializer;
 
 /**
@@ -39,5 +41,10 @@ public class ArrayArgument implements StructuredArgument {
     @Override
     public String toString() {
         return key + "=" + StructuredArguments.toString(values);
+    }
+
+    @Override
+    public Iterable<String> keys() {
+        return Set.of(key);
     }
 }

--- a/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/argument/JsonArgument.java
+++ b/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/argument/JsonArgument.java
@@ -15,6 +15,8 @@
 package software.amazon.lambda.powertools.logging.argument;
 
 import java.util.Objects;
+import java.util.Set;
+
 import software.amazon.lambda.powertools.logging.internal.JsonSerializer;
 
 /**
@@ -38,5 +40,10 @@ public class JsonArgument implements StructuredArgument {
     @Override
     public String toString() {
         return key + "=" + rawJson;
+    }
+
+    @Override
+    public Iterable<String> keys() {
+        return Set.of(key);
     }
 }

--- a/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/argument/KeyValueArgument.java
+++ b/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/argument/KeyValueArgument.java
@@ -15,6 +15,8 @@
 package software.amazon.lambda.powertools.logging.argument;
 
 import java.util.Objects;
+import java.util.Set;
+
 import software.amazon.lambda.powertools.logging.internal.JsonSerializer;
 
 /**
@@ -37,6 +39,11 @@ public class KeyValueArgument implements StructuredArgument {
     @Override
     public String toString() {
         return key + "=" + StructuredArguments.toString(value);
+    }
+
+    @Override
+    public Iterable<String> keys() {
+        return Set.of(getKey());
     }
 
     public String getKey() {

--- a/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/argument/StructuredArgument.java
+++ b/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/argument/StructuredArgument.java
@@ -15,7 +15,9 @@
 package software.amazon.lambda.powertools.logging.argument;
 
 import java.io.IOException;
+
 import org.slf4j.Logger;
+
 import software.amazon.lambda.powertools.logging.internal.JsonSerializer;
 
 /**
@@ -26,8 +28,10 @@ public interface StructuredArgument {
     /**
      * Writes the data associated with this argument to the given {@link JsonSerializer}.
      *
-     * @param serializer the {@link JsonSerializer} to produce JSON content
-     * @throws IOException if an I/O error occurs
+     * @param serializer
+     *            the {@link JsonSerializer} to produce JSON content
+     * @throws IOException
+     *             if an I/O error occurs
      */
     void writeTo(JsonSerializer serializer) throws IOException;
 
@@ -41,5 +45,13 @@ public interface StructuredArgument {
      * @return String representation of the data associated with this argument
      */
     String toString();
+
+    /**
+     * Returns the root-level log keys associated with this argument. If the argument has only one key, this method
+     * will return a single-element iterable.
+     *
+     * @return the keys associated with this argument
+     */
+    Iterable<String> keys();
 
 }

--- a/powertools-logging/src/test/java/software/amazon/lambda/powertools/logging/argument/StructuredArgumentsTest.java
+++ b/powertools-logging/src/test/java/software/amazon/lambda/powertools/logging/argument/StructuredArgumentsTest.java
@@ -49,6 +49,7 @@ class StructuredArgumentsTest {
         // THEN
         assertThat(sb.toString()).hasToString("\"basket\":{\"products\":[{\"id\":42,\"name\":\"Nintendo DS\",\"price\":299.45},{\"id\":98,\"name\":\"Playstation 5\",\"price\":499.99}]}");
         assertThat(argument.toString()).hasToString("basket=Basket{products=[Product{id=42, name='Nintendo DS', price=299.45}, Product{id=98, name='Playstation 5', price=499.99}]}");
+        assertThat(argument.keys()).containsExactlyInAnyOrder("basket");
     }
 
     @Test
@@ -64,11 +65,27 @@ class StructuredArgumentsTest {
 
         // THEN
         assertThat(sb.toString())
-                .contains("\"nds\":{\"id\":42,\"name\":\"Nintendo DS\",\"price\":299.45}")
+                .contains("\"nds\":{\"id\":42,\"name\":\"Nintendo DS\",\"price\":299.45},")
                 .contains("\"ps5\":{\"id\":98,\"name\":\"Playstation 5\",\"price\":499.99}");
         assertThat(argument.toString())
                 .contains("nds=Product{id=42, name='Nintendo DS', price=299.45}")
                 .contains("ps5=Product{id=98, name='Playstation 5', price=499.99}");
+        assertThat(argument.keys()).containsExactlyInAnyOrder("nds", "ps5");
+    }
+
+    @Test
+    void emptyMapArgument() throws IOException {
+        // GIVEN
+        Map<String, Product> catalog = new HashMap<>();
+
+        // WHEN
+        StructuredArgument argument = StructuredArguments.entries(catalog);
+        argument.writeTo(serializer);
+
+        // THEN
+        assertThat(sb.toString()).isEmpty();
+        assertThat(argument.toString()).hasToString("{}");
+        assertThat(argument.keys()).isEmpty();
     }
 
     @Test
@@ -86,6 +103,7 @@ class StructuredArgumentsTest {
         // THEN
         assertThat(sb.toString()).contains("\"products\":[{\"id\":42,\"name\":\"Nintendo DS\",\"price\":299.45},{\"id\":98,\"name\":\"Playstation 5\",\"price\":499.99}]");
         assertThat(argument.toString()).contains("products=[Product{id=42, name='Nintendo DS', price=299.45}, Product{id=98, name='Playstation 5', price=499.99}]");
+        assertThat(argument.keys()).containsExactlyInAnyOrder("products");
     }
 
     @Test
@@ -100,6 +118,7 @@ class StructuredArgumentsTest {
         // THEN
         assertThat(sb.toString()).contains("\"product\":{\"id\":42,\"name\":\"Nintendo DS\",\"price\":299.45}");
         assertThat(argument.toString()).contains("product={\"id\":42,\"name\":\"Nintendo DS\",\"price\":299.45}");
+        assertThat(argument.keys()).containsExactlyInAnyOrder("product");
     }
 
 }


### PR DESCRIPTION
**Issue #, if available:** https://github.com/aws-powertools/powertools-lambda-java/issues/1759

## Description of changes:

This PR fixes two problems for both the logback logging module as well as the log4j logging module:
1. Prevents users from accidentally overwriting reserved context keys such as `message`, `level`, Lambda context information, etc.
2. Fixes a bug in the `MapArgument` where JSON serialization was missing a comma if the map contained multiple root-level keys.

Note: In addition to unit tests, I ran E2E tests as well. Until E2E tests are restored in GitHub workflows, here is the output from running in my AWS account.

```
❯ mvn -Pe2e -B verify --file powertools-e2e-tests/pom.xml -Dtest="LoggingE2ET.java"
...
16:32:30.422 [main] INFO  software.amazon.lambda.powertools.testutils.Infrastructure - Uploading asset 3a7b20f10d24fa631c596730d62c85aff6d25420cc2ed78d6a7decf66e08a2e5.jar to cdk-hnb659fds-assets-*******-eu-west-1
16:32:34.738 [main] INFO  software.amazon.lambda.powertools.testutils.Infrastructure - Deploying 'LoggingE2ET-893080a1f7f7' on account *******
16:33:35.840 [main] INFO  software.amazon.lambda.powertools.testutils.Infrastructure - Stack LoggingE2ET-893080a1f7f7 successfully deployed
16:33:38.474 [main] INFO  software.amazon.lambda.powertools.testutils.Infrastructure - Deleting 'LoggingE2ET-893080a1f7f7' on account *******
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 86.50 s -- in software.amazon.lambda.powertools.LoggingE2ET
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
