### PR TITLE
fix(logging): Escape double-quotes when serializing strings into JSON.

### DIFF
--- a/powertools-logging/powertools-logging-logback/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaJsonEncoderTest.java
+++ b/powertools-logging/powertools-logging-logback/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaJsonEncoderTest.java
@@ -127,7 +127,8 @@ class LambdaJsonEncoderTest {
         assertThat(contentOf(logFile))
                 .contains("\"input\":{\"awsRegion\":\"eu-west-1\",\"body\":\"plop\",\"eventSource\":\"eb\",\"messageAttributes\":{\"keyAttribute\":{\"stringListValues\":[\"val1\",\"val2\",\"val3\"]}},\"messageId\":\"1212abcd\"}")
                 .contains("\"message\":\"1212abcd\"")
-                .contains("\"message\":\"Message body = plop and id = \"1212abcd\"\"");
+                // Should auto-escape double quotes around id
+                .contains("\"message\":\"Message body = plop and id = \\\"1212abcd\\\"\"");
         // Reserved keys should be ignored
         PowertoolsLoggedFields.stringValues().stream().forEach(reservedKey -> {
             assertThat(contentOf(logFile)).doesNotContain("\"" + reservedKey + "\":\"shouldBeIgnored\"");
@@ -158,7 +159,8 @@ class LambdaJsonEncoderTest {
         assertThat(contentOf(logFile))
                 .contains("\"input\":{\"awsRegion\":\"eu-west-1\",\"body\":\"plop\",\"eventSource\":\"eb\",\"messageAttributes\":{\"keyAttribute\":{\"stringListValues\":[\"val1\",\"val2\",\"val3\"]}},\"messageId\":\"1212abcd\"}")
                 .contains("\"message\":\"1212abcd\"")
-                .contains("\"message\":\"Message body = plop and id = \"1212abcd\"\"");
+                // Should auto-escape double quotes around id
+                .contains("\"message\":\"Message body = plop and id = \\\"1212abcd\\\"\"");
         // Reserved keys should be ignored
         PowertoolsLoggedFields.stringValues().stream().forEach(reservedKey -> {
             assertThat(contentOf(logFile)).doesNotContain("\"" + reservedKey + "\":\"shouldBeIgnored\"");
@@ -295,7 +297,8 @@ class LambdaJsonEncoderTest {
         File logFile = new File("target/logfile.json");
         assertThat(contentOf(logFile))
                 .contains("\"message\":\"Handler Event\"")
-                .contains("\"event\":\"{\"key\":\"value\"}\""); // logged as String for StreamHandler
+                // logged as String for StreamHandler (should auto-escape double-quotes to avoid breaking JSON format)
+                .contains("\"event\":\"{\\\"key\\\":\\\"value\\\"}\"");
     }
 
     @Test

--- a/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/internal/JsonSerializer.java
+++ b/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/internal/JsonSerializer.java
@@ -53,7 +53,7 @@ public class JsonSerializer implements AutoCloseable {
         }
         this.builder = builder;
     }
-    
+
     public void writeStartArray() {
         builder.append('[');
     }
@@ -84,7 +84,8 @@ public class JsonSerializer implements AutoCloseable {
         if (text == null) {
             writeNull();
         } else {
-            builder.append("\"").append(text).append("\"");
+            // Escape double quotes to avoid breaking JSON format
+            builder.append("\"").append(text.replace("\"", "\\\"")).append("\"");
         }
     }
 
@@ -314,7 +315,7 @@ public class JsonSerializer implements AutoCloseable {
             writeNull();
         } else {
             writeStartObject();
-            for (Iterator<? extends Map.Entry<?, ?>> entries = map.entrySet().iterator(); entries.hasNext(); ) {
+            for (Iterator<? extends Map.Entry<?, ?>> entries = map.entrySet().iterator(); entries.hasNext();) {
                 Map.Entry<?, ?> entry = entries.next();
                 writeObjectField(String.valueOf(entry.getKey()), entry.getValue());
                 if (entries.hasNext()) {
@@ -326,16 +327,16 @@ public class JsonSerializer implements AutoCloseable {
     }
 
     public void writeObject(Object value) {
-        
+
         // null
         if (value == null) {
             writeNull();
-        } 
-        
+        }
+
         else if (value instanceof String) {
             writeString((String) value);
-        } 
-        
+        }
+
         // number & boolean
         else if (value instanceof Number) {
             Number n = (Number) value;
@@ -364,8 +365,8 @@ public class JsonSerializer implements AutoCloseable {
             writeBoolean((Boolean) value);
         } else if (value instanceof AtomicBoolean) {
             writeBoolean(((AtomicBoolean) value).get());
-        } 
-        
+        }
+
         // list & collection
         else if (value instanceof List) {
             final List<?> list = (List<?>) value;
@@ -373,14 +374,13 @@ public class JsonSerializer implements AutoCloseable {
         } else if (value instanceof Collection) {
             final Collection<?> collection = (Collection<?>) value;
             writeArray(collection);
-        } 
-        
+        }
+
         // map
         else if (value instanceof Map) {
             final Map<?, ?> map = (Map<?, ?>) value;
             writeMap(map);
         }
-
 
         // arrays
         else if (value instanceof char[]) {
@@ -411,7 +411,7 @@ public class JsonSerializer implements AutoCloseable {
             final Object[] values = (Object[]) value;
             writeArray(values);
         }
-        
+
         else if (value instanceof JsonNode) {
             JsonNode node = (JsonNode) value;
 
@@ -462,7 +462,7 @@ public class JsonSerializer implements AutoCloseable {
                 case OBJECT:
                 case POJO:
                     writeStartObject();
-                    for (Iterator<Map.Entry<String, JsonNode>> entries = node.fields(); entries.hasNext(); ) {
+                    for (Iterator<Map.Entry<String, JsonNode>> entries = node.fields(); entries.hasNext();) {
                         Map.Entry<String, JsonNode> entry = entries.next();
                         writeObjectField(entry.getKey(), entry.getValue());
                         if (entries.hasNext()) {
@@ -475,7 +475,7 @@ public class JsonSerializer implements AutoCloseable {
                 case ARRAY:
                     ArrayNode arrayNode = (ArrayNode) node;
                     writeStartArray();
-                    for (Iterator<JsonNode> elements = arrayNode.elements(); elements.hasNext(); ) {
+                    for (Iterator<JsonNode> elements = arrayNode.elements(); elements.hasNext();) {
                         writeObject(elements.next());
                         if (elements.hasNext()) {
                             builder.append(',');
@@ -558,7 +558,7 @@ public class JsonSerializer implements AutoCloseable {
             writeNull();
         } else if (rootNode instanceof TextNode) {
             writeString(((TextNode) rootNode).asText());
-        } else if  (rootNode instanceof BooleanNode) {
+        } else if (rootNode instanceof BooleanNode) {
             writeBoolean(((BooleanNode) rootNode).asBoolean());
         } else if (rootNode instanceof NumericNode) {
             NumericNode numericNode = (NumericNode) rootNode;
@@ -595,5 +595,3 @@ public class JsonSerializer implements AutoCloseable {
         // nothing to do
     }
 }
-
-


### PR DESCRIPTION
**Issue #, if available:** N/A (found while working on something else)

## Description of changes:

This is a small change fixing an edge case where the JSON formatting of structured arguments in the logging module was broken. If a String contained double quotes they were not escaped leading to a broken JSON output in the Lambda logs.

### Example:

**Before**

```java
LOGGER.info("Message", entry("myString", "String with \"double quotes\""));
```

**Invalid JSON (inner double quotes are not escaped)**
`jq: parse error: Invalid numeric literal at ...`
```json
{
  "level": "INFO",
  "message": "Message",
  "cold_start": true,
  "function_arn": "arn:aws:lambda:us-east-1:***:function:***",
  "function_memory_size": 512,
  "function_name": "***",
  "function_request_id": "7e97091d-c48e-4bc2-809f-822ac34a316f",
  "function_version": "$LATEST",
  "service": "***",
  "timestamp": "2025-05-15T14:07:52.036Z",
  "myString": "String with "double quotes""
}
```

**After**

```java
LOGGER.info("Message", entry("myString", "String with \"double quotes\""));
```

**Valid JSON**

```json
{
  "level": "INFO",
  "message": "Message",
  "cold_start": true,
  "function_arn": "arn:aws:lambda:us-east-1:***:function:***",
  "function_memory_size": 512,
  "function_name": "***",
  "function_request_id": "7e97091d-c48e-4bc2-809f-822ac34a316f",
  "function_version": "$LATEST",
  "service": "***",
  "timestamp": "2025-05-15T14:07:52.036Z",
  "myString": "String with \"double quotes\""
}
```

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
