### PR TITLE
chore(ci): Update workflows to make v2 the default

### DIFF
--- a/.github/auto_assign-issues.yml
+++ b/.github/auto_assign-issues.yml
@@ -1,9 +1,0 @@
-addAssignees: true
-
-# The list of users to assign to new issues.
-# If empty or not provided, the repository owner is assigned
-assignees:
-  - scottgerring
-  - jeromevdl
-  - mriccia
-  - msailes

--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -38,7 +38,6 @@ on:
   push:
     branches:
       - main
-      - v2
     paths: # add other modules when there are under e2e tests
       - 'powertools-batch/**'
       - 'powertools-core/**'

--- a/.github/workflows/check-e2e.yml
+++ b/.github/workflows/check-e2e.yml
@@ -15,7 +15,6 @@ on:
   push:
       branches:
         - main
-        - v2
       paths: # add other modules when there are under e2e tests
         - 'powertools-batch/**'
         - 'powertools-core/**'

--- a/.github/workflows/check-spotbugs.yml
+++ b/.github/workflows/check-spotbugs.yml
@@ -9,7 +9,7 @@
 on:
   pull_request:
     branches:
-      - v2
+      - main
     paths:
       - 'powertools-batch/**'
       - 'powertools-core/**'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,16 +15,11 @@ name: Release Drafter
 run-name: Release Drafter
 
 jobs:
-<<<<<<< HEAD
-  update_release_draft:
-    runs-on: ubuntu-latest
-=======
   update_release:
     runs-on: ubuntu-latest  
     permissions:
       contents: write
       id-token: write
->>>>>>> 4a17172a (chore(automation): Update automation workflows (#1779))
     steps:
       - name: Relase Drafter
         uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
           retention-days: 1
 
   quality:
-    runs-on: ubuntu-latest
+    runs-on: aws-powertools_ubuntu-latest_8-core
     needs:
       - version_seal
     if: ${{ inputs.skip_checks == false }}
@@ -156,7 +156,7 @@ jobs:
           uploadSarifReport: false
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: aws-powertools_ubuntu-latest_8-core
     needs:
       - setup
       - quality
@@ -183,7 +183,7 @@ jobs:
           mvn -B install --file pom.xml
 
   publish:
-    runs-on: ubuntu-latest
+    runs-on: aws-powertools_ubuntu-latest_8-core
     if: ${{ github.repository == 'aws-powertools/powertools-lambda-java' && inputs.skip_publish == false }}
     needs:
       - build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
 
   publish:
     runs-on: aws-powertools_ubuntu-latest_8-core
-    if: ${{ github.repository == 'aws-powertools/powertools-lambda-java' && inputs.skip_publish == false }}
+    if: ${{ github.repository == 'aws-powertools/powertools-lambda-java' && inputs.skip_publish == false && always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     needs:
       - build
     environment: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,11 +254,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - id: tag
-        name: Create release
+        name: Create tag
         run: |
-          gh release create v${{ inputs.version }} --target $(git rev-parse HEAD)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          git tag -a v${{ inputs.version }} -m "Release v${{ inputs.version }}"
+          git push origin v${{ inputs.version }}
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
       - id: base
         name: Base
         run: |
-          echo build_version=$(test ${{ github.ref_name }} == "v2" && echo "v2" || echo "v1") >> $GITHUB_OUTPUT
+          echo build_version=$(test ${{ github.ref_name }} == "main" && echo "v2" || echo "v1") >> $GITHUB_OUTPUT
       - id: build_matrix_v1
         name: Build matrix (v1)
         if: ${{ steps.base.outputs.build_version == 'v1' }}

--- a/.github/workflows/security-branch-protections.yml
+++ b/.github/workflows/security-branch-protections.yml
@@ -43,7 +43,7 @@ jobs:
         # List of branches we want to monitor for protection changes
         branch:
           - main
-          - v2
+          - v1
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/security-dependabot.yml
+++ b/.github/workflows/security-dependabot.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'aws-powertools/powertools-lambda-java' }}
     permissions:
-      pull-requests: read
+      pull-requests: write
     steps:
       - id: dependabot-metadata
         name: Fetch Dependabot metadata

--- a/.github/workflows/security-osv.yml
+++ b/.github/workflows/security-osv.yml
@@ -13,14 +13,12 @@ on:
   pull_request:
     branches: 
       - main
-      - v2
   workflow_dispatch: {}
   schedule:
     - cron: "30 12 * * 1"
   push:
     branches:
       - main
-      - v2
 
 name: OpenSource Vulnerability Scanner
 run-name: OpenSource Vulnerability Scanner


### PR DESCRIPTION
**Issue #, if available:** #1866

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

Updates the workflows to make v2 (main branch) the default. I also increase the runner size to use our larger action runners for large tasks (release workflow)

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [] Update docs
* [X] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
