### PR TITLE
fix(metrics): Do not flush when no metrics were added to avoid printing root-level _aws dict

### DIFF
--- a/powertools-metrics/src/main/java/software/amazon/lambda/powertools/metrics/internal/EmfMetricsLogger.java
+++ b/powertools-metrics/src/main/java/software/amazon/lambda/powertools/metrics/internal/EmfMetricsLogger.java
@@ -164,8 +164,9 @@ public class EmfMetricsLogger implements Metrics {
             } else {
                 LOGGER.warn("No metrics were emitted");
             }
+        } else {
+            emfLogger.flush();
         }
-        emfLogger.flush();
     }
 
     @Override

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/internal/EmfMetricsLoggerTest.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/internal/EmfMetricsLoggerTest.java
@@ -51,7 +51,7 @@ class EmfMetricsLoggerTest {
 
     private Metrics metrics;
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final PrintStream standardOut = System.out;
+    private static final PrintStream standardOut = System.out;
     private final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
 
     @BeforeEach
@@ -180,7 +180,7 @@ class EmfMetricsLoggerTest {
         JsonNode dimensions = rootNode.get("_aws").get("CloudWatchMetrics").get(0).get("Dimensions").get(0);
         boolean hasDimension = false;
         for (JsonNode dimension : dimensions) {
-            if (dimension.asText().equals("CustomDimension")) {
+            if ("CustomDimension".equals(dimension.asText())) {
                 hasDimension = true;
                 break;
             }
@@ -233,9 +233,9 @@ class EmfMetricsLoggerTest {
         boolean hasDim2 = false;
         for (JsonNode dimension : dimensions) {
             String dimName = dimension.asText();
-            if (dimName.equals("Dim1")) {
+            if ("Dim1".equals(dimName)) {
                 hasDim1 = true;
-            } else if (dimName.equals("Dim2")) {
+            } else if ("Dim2".equals(dimName)) {
                 hasDim2 = true;
             }
         }

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/internal/EmfMetricsLoggerTest.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/internal/EmfMetricsLoggerTest.java
@@ -348,6 +348,8 @@ class EmfMetricsLoggerTest {
         // Read the log file and check for the warning
         String logContent = new String(Files.readAllBytes(logFile.toPath()), StandardCharsets.UTF_8);
         assertThat(logContent).contains("No metrics were emitted");
+        // No EMF output should be generated
+        assertThat(outputStreamCaptor.toString().trim()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
**Issue #, if available:** https://github.com/aws-powertools/powertools-lambda-java/issues/1890

## Description of changes:

Flushing without metrics has unexpected behavior in the `aws-embedded-metrics` library. It prints the root-level section of the `_aws` EMF dict to STDOUT which we don't want. We want to log a simple warning only.

Before:

```json
{"Service":"payment","logStreamId":"$LATEST","functionVersion":"$LATEST","executionEnvironment":"AWS_Lambda_java11"}
```

After:

```
// No output
```

I added a unit test catching this bug.

**Note: The PMD linting about Empty Catch Blocks is expected. We don't want to bubble up EMF exceptions to the consumer because we already do our own validation.**

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)