### PR TITLE
feat: add support for batch execution in parallel with custom Executor

### DIFF
--- a/examples/powertools-examples-batch/src/main/java/org/demo/batch/dynamo/DynamoDBStreamBatchHandlerParallel.java
+++ b/examples/powertools-examples-batch/src/main/java/org/demo/batch/dynamo/DynamoDBStreamBatchHandlerParallel.java
@@ -1,0 +1,37 @@
+package org.demo.batch.dynamo;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+import com.amazonaws.services.lambda.runtime.events.StreamsEventResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.lambda.powertools.batch.BatchMessageHandlerBuilder;
+import software.amazon.lambda.powertools.batch.handler.BatchMessageHandler;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class DynamoDBStreamBatchHandlerParallel implements RequestHandler<DynamodbEvent, StreamsEventResponse> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DynamoDBStreamBatchHandlerParallel.class);
+    private final BatchMessageHandler<DynamodbEvent, StreamsEventResponse> handler;
+    private final ExecutorService executor;
+
+    public DynamoDBStreamBatchHandlerParallel() {
+        handler = new BatchMessageHandlerBuilder()
+                .withDynamoDbBatchHandler()
+                .buildWithRawMessageHandler(this::processMessage);
+        executor = Executors.newFixedThreadPool(2);
+    }
+
+    @Override
+    public StreamsEventResponse handleRequest(DynamodbEvent ddbEvent, Context context) {
+        return handler.processBatchInParallel(ddbEvent, context, executor);
+    }
+
+    private void processMessage(DynamodbEvent.DynamodbStreamRecord dynamodbStreamRecord, Context context) {
+        LOGGER.info("Processing DynamoDB Stream Record" + dynamodbStreamRecord);
+    }
+
+}

--- a/examples/powertools-examples-batch/src/main/java/org/demo/batch/kinesis/KinesisBatchHandlerParallel.java
+++ b/examples/powertools-examples-batch/src/main/java/org/demo/batch/kinesis/KinesisBatchHandlerParallel.java
@@ -1,0 +1,39 @@
+package org.demo.batch.kinesis;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.KinesisEvent;
+import com.amazonaws.services.lambda.runtime.events.StreamsEventResponse;
+import org.demo.batch.model.Product;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.lambda.powertools.batch.BatchMessageHandlerBuilder;
+import software.amazon.lambda.powertools.batch.handler.BatchMessageHandler;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class KinesisBatchHandlerParallel implements RequestHandler<KinesisEvent, StreamsEventResponse> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KinesisBatchHandlerParallel.class);
+    private final BatchMessageHandler<KinesisEvent, StreamsEventResponse> handler;
+    private final ExecutorService executor;
+
+
+    public KinesisBatchHandlerParallel() {
+        handler = new BatchMessageHandlerBuilder()
+                .withKinesisBatchHandler()
+                .buildWithMessageHandler(this::processMessage, Product.class);
+        executor = Executors.newFixedThreadPool(2);
+    }
+
+    @Override
+    public StreamsEventResponse handleRequest(KinesisEvent kinesisEvent, Context context) {
+        return handler.processBatchInParallel(kinesisEvent, context, executor);
+    }
+
+    private void processMessage(Product p, Context c) {
+        LOGGER.info("Processing product " + p);
+    }
+
+}

--- a/examples/powertools-examples-batch/src/main/java/org/demo/batch/sqs/SqsBatchHandlerParallel.java
+++ b/examples/powertools-examples-batch/src/main/java/org/demo/batch/sqs/SqsBatchHandlerParallel.java
@@ -1,0 +1,37 @@
+package org.demo.batch.sqs;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import org.demo.batch.model.Product;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.lambda.powertools.batch.BatchMessageHandlerBuilder;
+import software.amazon.lambda.powertools.batch.handler.BatchMessageHandler;
+import software.amazon.lambda.powertools.logging.Logging;
+import software.amazon.lambda.powertools.tracing.Tracing;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class SqsBatchHandlerParallel extends AbstractSqsBatchHandler implements RequestHandler<SQSEvent, SQSBatchResponse> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SqsBatchHandlerParallel.class);
+    private final BatchMessageHandler<SQSEvent, SQSBatchResponse> handler;
+    private final ExecutorService executor;
+
+    public SqsBatchHandlerParallel() {
+        handler = new BatchMessageHandlerBuilder()
+                .withSqsBatchHandler()
+                .buildWithMessageHandler(this::processMessage, Product.class);
+        executor = Executors.newFixedThreadPool(2);
+    }
+
+    @Logging
+    @Tracing
+    @Override
+    public SQSBatchResponse handleRequest(SQSEvent sqsEvent, Context context) {
+        LOGGER.info("Processing batch of {} messages", sqsEvent.getRecords().size());
+        return handler.processBatchInParallel(sqsEvent, context, executor);
+    }
+}

--- a/powertools-batch/src/main/java/software/amazon/lambda/powertools/batch/handler/BatchMessageHandler.java
+++ b/powertools-batch/src/main/java/software/amazon/lambda/powertools/batch/handler/BatchMessageHandler.java
@@ -16,6 +16,9 @@ package software.amazon.lambda.powertools.batch.handler;
 
 import com.amazonaws.services.lambda.runtime.Context;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+
 /**
  * The basic interface a batch message handler must meet.
  *
@@ -50,4 +53,14 @@ public interface BatchMessageHandler<E, R> {
      * @return A partial batch response
      */
     R processBatchInParallel(E event, Context context);
+
+
+    /**
+     * Same as {@link #processBatchInParallel(Object, Context)} but with an option to provide custom {@link Executor}
+     * @param event   The Lambda event containing the batch to process
+     * @param context The lambda context
+     * @param executor Custom executor to use for parallel processing
+     * @return A partial batch response
+     */
+    R processBatchInParallel(E event, Context context, Executor executor);
 }

--- a/powertools-batch/src/main/java/software/amazon/lambda/powertools/batch/handler/KinesisStreamsBatchMessageHandler.java
+++ b/powertools-batch/src/main/java/software/amazon/lambda/powertools/batch/handler/KinesisStreamsBatchMessageHandler.java
@@ -18,8 +18,12 @@ package software.amazon.lambda.powertools.batch.handler;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.KinesisEvent;
 import com.amazonaws.services.lambda.runtime.events.StreamsEventResponse;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -77,12 +81,31 @@ public class KinesisStreamsBatchMessageHandler<M> implements BatchMessageHandler
                 .parallelStream() // Parallel processing
                 .map(eventRecord -> {
                     multiThreadMDC.copyMDCToThread(Thread.currentThread().getName());
-                    return processBatchItem(eventRecord, context);
+                    Optional<StreamsEventResponse.BatchItemFailure> failureOpt = processBatchItem(eventRecord, context);
+                    multiThreadMDC.removeThread(Thread.currentThread().getName());
+                    return failureOpt;
                 })
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(Collectors.toList());
 
+        return StreamsEventResponse.builder().withBatchItemFailures(batchItemFailures).build();
+    }
+
+    @Override
+    public StreamsEventResponse processBatchInParallel(KinesisEvent event, Context context, Executor executor) {
+        MultiThreadMDC multiThreadMDC = new MultiThreadMDC();
+
+        List<StreamsEventResponse.BatchItemFailure> batchItemFailures = new ArrayList<>();
+        List<CompletableFuture<Void>> futures = event.getRecords().stream()
+                .map(eventRecord -> CompletableFuture.runAsync(() -> {
+                    multiThreadMDC.copyMDCToThread(Thread.currentThread().getName());
+                    Optional<StreamsEventResponse.BatchItemFailure> failureOpt = processBatchItem(eventRecord, context);
+                    failureOpt.ifPresent(batchItemFailures::add);
+                    multiThreadMDC.removeThread(Thread.currentThread().getName());
+                }, executor))
+                .collect(Collectors.toList());
+        futures.forEach(CompletableFuture::join);
         return StreamsEventResponse.builder().withBatchItemFailures(batchItemFailures).build();
     }
 

--- a/powertools-batch/src/main/java/software/amazon/lambda/powertools/batch/internal/MultiThreadMDC.java
+++ b/powertools-batch/src/main/java/software/amazon/lambda/powertools/batch/internal/MultiThreadMDC.java
@@ -44,4 +44,11 @@ public class MultiThreadMDC {
             mdcAwareThreads.add(thread);
         }
     }
+
+    public void removeThread(String thread) {
+        if (mdcAwareThreads.contains(thread)) {
+            LOGGER.debug("Removing thread {}", thread);
+            mdcAwareThreads.remove(thread);
+        }
+    }
 }


### PR DESCRIPTION
#1864

## Description of changes:

Add a new method in the BatchHandler class which allows users to pass their custom Executor for processing messages in parallel.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
