### PR TITLE
fix(kafka): Handle message indices in proto data also for Glue Schema Registry

### DIFF
--- a/examples/powertools-examples-core-utilities/cdk/app/pom.xml
+++ b/examples/powertools-examples-core-utilities/cdk/app/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.15.0</version>
+            <version>3.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/examples/powertools-examples-core-utilities/gradle/build.gradle
+++ b/examples/powertools-examples-core-utilities/gradle/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
-    implementation 'com.amazonaws:aws-lambda-java-events:3.11.0'
+    implementation 'com.amazonaws:aws-lambda-java-events:3.16.0'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2'
     implementation 'org.aspectj:aspectjrt:1.9.20.1'
     aspect 'software.amazon.lambda:powertools-tracing:2.1.0'

--- a/examples/powertools-examples-core-utilities/kotlin/build.gradle.kts
+++ b/examples/powertools-examples-core-utilities/kotlin/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     implementation("com.amazonaws:aws-lambda-java-core:1.2.3")
     implementation("com.fasterxml.jackson.core:jackson-annotations:2.15.1")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.15.3")
-    implementation("com.amazonaws:aws-lambda-java-events:3.11.3")
+    implementation("com.amazonaws:aws-lambda-java-events:3.16.0")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2")
     implementation("org.aspectj:aspectjrt:1.9.20.1")
     aspect("software.amazon.lambda:powertools-tracing:2.1.0")

--- a/examples/powertools-examples-core-utilities/sam-graalvm/pom.xml
+++ b/examples/powertools-examples-core-utilities/sam-graalvm/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.11.3</version>
+            <version>3.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/examples/powertools-examples-core-utilities/sam/pom.xml
+++ b/examples/powertools-examples-core-utilities/sam/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.15.0</version>
+            <version>3.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/examples/powertools-examples-core-utilities/serverless/pom.xml
+++ b/examples/powertools-examples-core-utilities/serverless/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.15.0</version>
+            <version>3.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/examples/powertools-examples-core-utilities/terraform/pom.xml
+++ b/examples/powertools-examples-core-utilities/terraform/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.15.0</version>
+            <version>3.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/examples/powertools-examples-idempotency/pom.xml
+++ b/examples/powertools-examples-idempotency/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.15.0</version>
+            <version>3.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/examples/powertools-examples-kafka/events/kafka-protobuf-event.json
+++ b/examples/powertools-examples-kafka/events/kafka-protobuf-event.json
@@ -30,7 +30,11 @@
           {
             "headerKey": [104, 101, 97, 100, 101, 114, 86, 97, 108, 117, 101]
           }
-        ]
+        ],
+        "valueSchemaMetadata": {
+          "schemaId": "123",
+          "dataFormat": "PROTOBUF"
+        }
       },
       {
         "topic": "mytopic",
@@ -39,12 +43,34 @@
         "timestamp": 1545084650989,
         "timestampType": "CREATE_TIME",
         "key": null,
-        "value": "AgEACOkHEgZMYXB0b3AZUrgehes/j0A=",
+        "value": "BAIACOkHEgZMYXB0b3AZUrgehes/j0A=",
         "headers": [
           {
             "headerKey": [104, 101, 97, 100, 101, 114, 86, 97, 108, 117, 101]
           }
-        ]
+        ],
+        "valueSchemaMetadata": {
+          "schemaId": "456",
+          "dataFormat": "PROTOBUF"
+        }
+      },
+      {
+        "topic": "mytopic",
+        "partition": 0,
+        "offset": 18,
+        "timestamp": 1545084650990,
+        "timestampType": "CREATE_TIME",
+        "key": "NDI=",
+        "value": "AQjpBxIGTGFwdG9wGVK4HoXrP49A",
+        "headers": [
+          {
+            "headerKey": [104, 101, 97, 100, 101, 114, 86, 97, 108, 117, 101]
+          }
+        ],
+        "valueSchemaMetadata": {
+          "schemaId": "12345678-1234-1234-1234-123456789012",
+          "dataFormat": "PROTOBUF"
+        }
       }
     ]
   }

--- a/examples/powertools-examples-kafka/tools/pom.xml
+++ b/examples/powertools-examples-kafka/tools/pom.xml
@@ -13,6 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <avro.version>1.12.0</avro.version>
         <protobuf.version>4.31.0</protobuf.version>
+        <kafka-clients.version>4.0.0</kafka-clients.version>
     </properties>
 
     <dependencies>
@@ -25,6 +26,11 @@
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>${protobuf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka-clients.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/examples/powertools-examples-kafka/tools/src/main/java/org/demo/kafka/tools/GenerateProtobufSamples.java
+++ b/examples/powertools-examples-kafka/tools/src/main/java/org/demo/kafka/tools/GenerateProtobufSamples.java
@@ -2,8 +2,10 @@ package org.demo.kafka.tools;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Base64;
 
+import org.apache.kafka.common.utils.ByteUtils;
 import org.demo.kafka.protobuf.ProtobufProduct;
 
 import com.google.protobuf.CodedOutputStream;
@@ -19,37 +21,42 @@ public final class GenerateProtobufSamples {
     }
 
     public static void main(String[] args) throws IOException {
-        // Create a single product that will be used for all three scenarios
+        // Create a single product that will be used for all four scenarios
         ProtobufProduct product = ProtobufProduct.newBuilder()
                 .setId(1001)
                 .setName("Laptop")
                 .setPrice(999.99)
                 .build();
 
-        // Create three different serializations of the same product
+        // Create four different serializations of the same product
         String standardProduct = serializeAndEncode(product);
-        String productWithSimpleIndex = serializeWithSimpleMessageIndex(product);
-        String productWithComplexIndex = serializeWithComplexMessageIndex(product);
+        String productWithConfluentSimpleIndex = serializeWithConfluentSimpleMessageIndex(product);
+        String productWithConfluentComplexIndex = serializeWithConfluentComplexMessageIndex(product);
+        String productWithGlueMagicByte = serializeWithGlueMagicByte(product);
 
         // Serialize and encode an integer key (same for all records)
         String encodedKey = serializeAndEncodeInteger(42);
 
         // Print the results
-        System.out.println("Base64 encoded Protobuf products with different message index scenarios:");
-        System.out.println("\n1. Standard Protobuf (no message index):");
+        System.out.println("Base64 encoded Protobuf products with different scenarios:");
+        System.out.println("\n1. Plain Protobuf (no schema registry):");
         System.out.println("value: \"" + standardProduct + "\"");
 
-        System.out.println("\n2. Simple Message Index (single 0):");
-        System.out.println("value: \"" + productWithSimpleIndex + "\"");
+        System.out.println("\n2. Confluent with Simple Message Index (optimized single 0):");
+        System.out.println("value: \"" + productWithConfluentSimpleIndex + "\"");
 
-        System.out.println("\n3. Complex Message Index (array [1,0]):");
-        System.out.println("value: \"" + productWithComplexIndex + "\"");
+        System.out.println("\n3. Confluent with Complex Message Index (array [1,0]):");
+        System.out.println("value: \"" + productWithConfluentComplexIndex + "\"");
+
+        System.out.println("\n4. Glue with Magic Byte:");
+        System.out.println("value: \"" + productWithGlueMagicByte + "\"");
 
         // Print the merged event structure
         System.out.println("\n" + "=".repeat(80));
-        System.out.println("MERGED EVENT WITH ALL THREE SCENARIOS");
+        System.out.println("MERGED EVENT WITH ALL FOUR SCENARIOS");
         System.out.println("=".repeat(80));
-        printSampleEvent(encodedKey, standardProduct, productWithSimpleIndex, productWithComplexIndex);
+        printSampleEvent(encodedKey, standardProduct, productWithConfluentSimpleIndex, productWithConfluentComplexIndex,
+                productWithGlueMagicByte);
     }
 
     private static String serializeAndEncode(ProtobufProduct product) {
@@ -57,39 +64,59 @@ public final class GenerateProtobufSamples {
     }
 
     /**
-     * Serializes a protobuf product with a simple Confluent message index (single 0).
+     * Serializes a protobuf product with a simple Confluent message index (optimized single 0).
      * Format: [0][protobuf_data]
      * 
      * @see {@link https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format}
      */
-    private static String serializeWithSimpleMessageIndex(ProtobufProduct product) throws IOException {
+    private static String serializeWithConfluentSimpleMessageIndex(ProtobufProduct product) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        CodedOutputStream codedOutput = CodedOutputStream.newInstance(baos);
 
-        // Write simple message index (single 0)
-        codedOutput.writeUInt32NoTag(0);
+        // Write optimized simple message index for Confluent (single 0 byte for [0])
+        baos.write(0);
 
         // Write the protobuf data
-        product.writeTo(codedOutput);
+        baos.write(product.toByteArray());
 
-        codedOutput.flush();
         return Base64.getEncoder().encodeToString(baos.toByteArray());
     }
 
     /**
      * Serializes a protobuf product with a complex Confluent message index (array [1,0]).
-     * Format: [2][1][0][protobuf_data] where 2 is the array length
+     * Format: [2][1][0][protobuf_data] where 2 is the array length using varint encoding
      * 
      * @see {@link https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format}
      */
-    private static String serializeWithComplexMessageIndex(ProtobufProduct product) throws IOException {
+    private static String serializeWithConfluentComplexMessageIndex(ProtobufProduct product) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        // Write complex message index array [1,0] using ByteUtils
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+        ByteUtils.writeVarint(2, buffer); // Array length
+        ByteUtils.writeVarint(1, buffer); // First index value
+        ByteUtils.writeVarint(0, buffer); // Second index value
+
+        buffer.flip();
+        byte[] indexData = new byte[buffer.remaining()];
+        buffer.get(indexData);
+        baos.write(indexData);
+
+        // Write the protobuf data
+        baos.write(product.toByteArray());
+
+        return Base64.getEncoder().encodeToString(baos.toByteArray());
+    }
+
+    /**
+     * Serializes a protobuf product with Glue magic byte.
+     * Format: [1][protobuf_data] where 1 is the magic byte
+     */
+    private static String serializeWithGlueMagicByte(ProtobufProduct product) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         CodedOutputStream codedOutput = CodedOutputStream.newInstance(baos);
 
-        // Write complex message index array [1,0]
-        codedOutput.writeUInt32NoTag(2); // Array length
-        codedOutput.writeUInt32NoTag(1); // First index value
-        codedOutput.writeUInt32NoTag(0); // Second index value
+        // Write Glue magic byte (single UInt32)
+        codedOutput.writeUInt32NoTag(1);
 
         // Write the protobuf data
         product.writeTo(codedOutput);
@@ -103,8 +130,8 @@ public final class GenerateProtobufSamples {
         return Base64.getEncoder().encodeToString(value.toString().getBytes());
     }
 
-    private static void printSampleEvent(String key, String standardProduct, String simpleIndexProduct,
-            String complexIndexProduct) {
+    private static void printSampleEvent(String key, String standardProduct, String confluentSimpleProduct,
+            String confluentComplexProduct, String glueProduct) {
         System.out.println("{\n" +
                 "  \"eventSource\": \"aws:kafka\",\n" +
                 "  \"eventSourceArn\": \"arn:aws:kafka:us-east-1:0123456789019:cluster/SalesCluster/abcd1234-abcd-cafe-abab-9876543210ab-4\",\n"
@@ -134,12 +161,16 @@ public final class GenerateProtobufSamples {
                 "        \"timestamp\": 1545084650988,\n" +
                 "        \"timestampType\": \"CREATE_TIME\",\n" +
                 "        \"key\": \"" + key + "\",\n" +
-                "        \"value\": \"" + simpleIndexProduct + "\",\n" +
+                "        \"value\": \"" + confluentSimpleProduct + "\",\n" +
                 "        \"headers\": [\n" +
                 "          {\n" +
                 "            \"headerKey\": [104, 101, 97, 100, 101, 114, 86, 97, 108, 117, 101]\n" +
                 "          }\n" +
-                "        ]\n" +
+                "        ],\n" +
+                "        \"valueSchemaMetadata\": {\n" +
+                "          \"schemaId\": \"123\",\n" +
+                "          \"dataFormat\": \"PROTOBUF\"\n" +
+                "        }\n" +
                 "      },\n" +
                 "      {\n" +
                 "        \"topic\": \"mytopic\",\n" +
@@ -148,12 +179,34 @@ public final class GenerateProtobufSamples {
                 "        \"timestamp\": 1545084650989,\n" +
                 "        \"timestampType\": \"CREATE_TIME\",\n" +
                 "        \"key\": null,\n" +
-                "        \"value\": \"" + complexIndexProduct + "\",\n" +
+                "        \"value\": \"" + confluentComplexProduct + "\",\n" +
                 "        \"headers\": [\n" +
                 "          {\n" +
                 "            \"headerKey\": [104, 101, 97, 100, 101, 114, 86, 97, 108, 117, 101]\n" +
                 "          }\n" +
-                "        ]\n" +
+                "        ],\n" +
+                "        \"valueSchemaMetadata\": {\n" +
+                "          \"schemaId\": \"456\",\n" +
+                "          \"dataFormat\": \"PROTOBUF\"\n" +
+                "        }\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"topic\": \"mytopic\",\n" +
+                "        \"partition\": 0,\n" +
+                "        \"offset\": 18,\n" +
+                "        \"timestamp\": 1545084650990,\n" +
+                "        \"timestampType\": \"CREATE_TIME\",\n" +
+                "        \"key\": \"" + key + "\",\n" +
+                "        \"value\": \"" + glueProduct + "\",\n" +
+                "        \"headers\": [\n" +
+                "          {\n" +
+                "            \"headerKey\": [104, 101, 97, 100, 101, 114, 86, 97, 108, 117, 101]\n" +
+                "          }\n" +
+                "        ],\n" +
+                "        \"valueSchemaMetadata\": {\n" +
+                "          \"schemaId\": \"12345678-1234-1234-1234-123456789012\",\n" +
+                "          \"dataFormat\": \"PROTOBUF\"\n" +
+                "        }\n" +
                 "      }\n" +
                 "    ]\n" +
                 "  }\n" +

--- a/examples/powertools-examples-parameters/sam-graalvm/pom.xml
+++ b/examples/powertools-examples-parameters/sam-graalvm/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.15.0</version>
+            <version>3.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/examples/powertools-examples-parameters/sam/pom.xml
+++ b/examples/powertools-examples-parameters/sam/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.15.0</version>
+            <version>3.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/examples/powertools-examples-serialization/pom.xml
+++ b/examples/powertools-examples-serialization/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
-            <version>3.15.0</version>
+            <version>3.16.0</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <payloadoffloading-common.version>2.2.0</payloadoffloading-common.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <lambda.core.version>1.2.3</lambda.core.version>
-        <lambda.events.version>3.15.0</lambda.events.version>
+        <lambda.events.version>3.16.0</lambda.events.version>
         <lambda.serial.version>1.1.5</lambda.serial.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <aspectj.version>1.9.7</aspectj.version>

--- a/powertools-kafka/src/main/java/software/amazon/lambda/powertools/kafka/serializers/AbstractKafkaDeserializer.java
+++ b/powertools-kafka/src/main/java/software/amazon/lambda/powertools/kafka/serializers/AbstractKafkaDeserializer.java
@@ -41,12 +41,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 abstract class AbstractKafkaDeserializer implements PowertoolsDeserializer {
     protected static final ObjectMapper objectMapper = new ObjectMapper()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    private static final Integer GLUE_SCHEMA_ID_LENGTH = 16;
+    private static final Integer GLUE_SCHEMA_ID_LENGTH = 36;
 
     public enum SchemaRegistryType {
-        CONFLUENT,
-        GLUE,
-        NONE
+        CONFLUENT, GLUE, NONE
     }
 
     /**
@@ -197,7 +195,8 @@ abstract class AbstractKafkaDeserializer implements PowertoolsDeserializer {
                 Optional.empty());
     }
 
-    private <T> T deserializeField(String encodedData, Class<T> type, String fieldName, SchemaRegistryType schemaRegistryType) {
+    private <T> T deserializeField(String encodedData, Class<T> type, String fieldName,
+            SchemaRegistryType schemaRegistryType) {
         if (encodedData == null) {
             return null;
         }
@@ -239,10 +238,8 @@ abstract class AbstractKafkaDeserializer implements PowertoolsDeserializer {
         return null;
     }
 
-    // The Assumption is that there will always be only one schema registry used, either Glue or Confluent, for both key
-    // and value.
-    protected SchemaRegistryType extractSchemaRegistryType(KafkaEvent.KafkaEventRecord eventRecord) {
-
+    private SchemaRegistryType extractSchemaRegistryType(KafkaEvent.KafkaEventRecord eventRecord) {
+        // This method is used for both key and value, so we try to extract the schema id from both fields
         String schemaId = extractValueSchemaId(eventRecord);
         if (schemaId == null) {
             schemaId = extractKeySchemaId(eventRecord);
@@ -266,7 +263,8 @@ abstract class AbstractKafkaDeserializer implements PowertoolsDeserializer {
      * @return The deserialized object
      * @throws IOException If deserialization fails
      */
-    protected abstract <T> T deserializeObject(byte[] data, Class<T> type, SchemaRegistryType schemaRegistryType) throws IOException;
+    protected abstract <T> T deserializeObject(byte[] data, Class<T> type, SchemaRegistryType schemaRegistryType)
+            throws IOException;
 
     /**
      * Main deserialize method that handles primitive types and delegates to subclasses for complex types and

--- a/powertools-kafka/src/main/java/software/amazon/lambda/powertools/kafka/serializers/KafkaAvroDeserializer.java
+++ b/powertools-kafka/src/main/java/software/amazon/lambda/powertools/kafka/serializers/KafkaAvroDeserializer.java
@@ -26,7 +26,7 @@ import org.apache.avro.specific.SpecificRecordBase;
 public class KafkaAvroDeserializer extends AbstractKafkaDeserializer {
 
     @Override
-    protected <T> T deserializeObject(byte[] data, Class<T> type) throws IOException {
+    protected <T> T deserializeObject(byte[] data, Class<T> type, SchemaRegistryType schemaRegistryType) throws IOException {
         // If no Avro generated class is passed we cannot deserialize using Avro
         if (SpecificRecordBase.class.isAssignableFrom(type)) {
             try {

--- a/powertools-kafka/src/main/java/software/amazon/lambda/powertools/kafka/serializers/KafkaAvroDeserializer.java
+++ b/powertools-kafka/src/main/java/software/amazon/lambda/powertools/kafka/serializers/KafkaAvroDeserializer.java
@@ -26,7 +26,8 @@ import org.apache.avro.specific.SpecificRecordBase;
 public class KafkaAvroDeserializer extends AbstractKafkaDeserializer {
 
     @Override
-    protected <T> T deserializeObject(byte[] data, Class<T> type, SchemaRegistryType schemaRegistryType) throws IOException {
+    protected <T> T deserializeObject(byte[] data, Class<T> type, SchemaRegistryType schemaRegistryType)
+            throws IOException {
         // If no Avro generated class is passed we cannot deserialize using Avro
         if (SpecificRecordBase.class.isAssignableFrom(type)) {
             try {

--- a/powertools-kafka/src/main/java/software/amazon/lambda/powertools/kafka/serializers/KafkaJsonDeserializer.java
+++ b/powertools-kafka/src/main/java/software/amazon/lambda/powertools/kafka/serializers/KafkaJsonDeserializer.java
@@ -14,7 +14,6 @@ package software.amazon.lambda.powertools.kafka.serializers;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.rmi.UnexpectedException;
 
 /**
  * Deserializer for Kafka records using JSON format.
@@ -22,7 +21,8 @@ import java.rmi.UnexpectedException;
 public class KafkaJsonDeserializer extends AbstractKafkaDeserializer {
 
     @Override
-    protected <T> T deserializeObject(byte[] data, Class<T> type, SchemaRegistryType schemaRegistryType) throws IOException {
+    protected <T> T deserializeObject(byte[] data, Class<T> type, SchemaRegistryType schemaRegistryType)
+            throws IOException {
         String decodedStr = new String(data, StandardCharsets.UTF_8);
 
         return objectMapper.readValue(decodedStr, type);

--- a/powertools-kafka/src/main/java/software/amazon/lambda/powertools/kafka/serializers/KafkaJsonDeserializer.java
+++ b/powertools-kafka/src/main/java/software/amazon/lambda/powertools/kafka/serializers/KafkaJsonDeserializer.java
@@ -14,6 +14,7 @@ package software.amazon.lambda.powertools.kafka.serializers;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.rmi.UnexpectedException;
 
 /**
  * Deserializer for Kafka records using JSON format.
@@ -21,7 +22,7 @@ import java.nio.charset.StandardCharsets;
 public class KafkaJsonDeserializer extends AbstractKafkaDeserializer {
 
     @Override
-    protected <T> T deserializeObject(byte[] data, Class<T> type) throws IOException {
+    protected <T> T deserializeObject(byte[] data, Class<T> type, SchemaRegistryType schemaRegistryType) throws IOException {
         String decodedStr = new String(data, StandardCharsets.UTF_8);
 
         return objectMapper.readValue(decodedStr, type);

--- a/powertools-kafka/src/main/java/software/amazon/lambda/powertools/kafka/serializers/KafkaProtobufDeserializer.java
+++ b/powertools-kafka/src/main/java/software/amazon/lambda/powertools/kafka/serializers/KafkaProtobufDeserializer.java
@@ -13,7 +13,9 @@
 package software.amazon.lambda.powertools.kafka.serializers;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
+import org.apache.kafka.common.utils.ByteUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,18 +38,16 @@ public class KafkaProtobufDeserializer extends AbstractKafkaDeserializer {
 
     @Override
     @SuppressWarnings("unchecked")
-    protected <T> T deserializeObject(byte[] data, Class<T> type) throws IOException {
-        // If no Protobuf generated class is passed we cannot deserialize using Protobuf
+    protected <T> T deserializeObject(byte[] data, Class<T> type,  SchemaRegistryType schemaRegistryType) throws IOException {
+        // If no Protobuf generated class is passed, we cannot deserialize using Protobuf
         if (Message.class.isAssignableFrom(type)) {
-            try {
-                // Get the parser from the generated Protobuf class
-                Parser<Message> parser = (Parser<Message>) type.getMethod("parser").invoke(null);
-
-                // Try to deserialize the data, handling potential Confluent message indices
-                Message message = deserializeWithMessageIndexHandling(data, parser);
-                return type.cast(message);
-            } catch (Exception e) {
-                throw new IOException("Failed to deserialize Protobuf data.", e);
+            switch (schemaRegistryType) {
+                case GLUE:
+                    return glueDeserializer(data, type);
+                case CONFLUENT:
+                    return confluentDeserializer(data, type);
+                default:
+                    return defaultDeserializer(data, type);
             }
         } else {
             throw new IOException("Unsupported type for Protobuf deserialization: " + type.getName() + ". "
@@ -56,44 +56,55 @@ public class KafkaProtobufDeserializer extends AbstractKafkaDeserializer {
         }
     }
 
-    private Message deserializeWithMessageIndexHandling(byte[] data, Parser<Message> parser) throws IOException {
+    private <T> T defaultDeserializer(byte[] data, Class<T> type) throws IOException {
         try {
-            LOGGER.debug("Attempting to deserialize as standard protobuf data");
-            return parser.parseFrom(data);
+            LOGGER.info("Using default Protobuf deserializer");
+            Parser<Message> parser = (Parser<Message>) type.getMethod("parser").invoke(null);
+            Message message = parser.parseFrom(data);
+            return type.cast(message);
         } catch (Exception e) {
-            LOGGER.debug("Standard protobuf parsing failed, attempting Confluent message-index handling");
-            return deserializeWithMessageIndex(data, parser);
+            throw new IOException("Failed to deserialize Protobuf data.", e);
         }
     }
 
-    private Message deserializeWithMessageIndex(byte[] data, Parser<Message> parser) throws IOException {
-        CodedInputStream codedInputStream = CodedInputStream.newInstance(data);
-
+    private <T> T confluentDeserializer(byte[] data, Class<T> type) throws IOException {
         try {
-            // https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format
-            // Read the first varint - this could be:
-            // 1. A single 0 (simple case - first message type)
-            // 2. The length of the message index array (complex case)
-            int firstValue = codedInputStream.readUInt32();
 
-            if (firstValue == 0) {
-                // Simple case: Single 0 byte means first message type
-                LOGGER.debug("Found simple message-index case (single 0), parsing remaining data as protobuf");
-                return parser.parseFrom(codedInputStream);
-            } else {
-                // Complex case: firstValue is the length of the message index array
-                LOGGER.debug("Found complex message-index case with array length: {}, skipping {} message index values",
-                        firstValue, firstValue);
-                for (int i = 0; i < firstValue; i++) {
-                    codedInputStream.readUInt32(); // Skip each message index value
+            LOGGER.info("Using confluentDeserializer");
+            Parser<Message> parser = (Parser<Message>) type.getMethod("parser").invoke(null);
+            ByteBuffer buffer = ByteBuffer.wrap(data);
+            int size = ByteUtils.readVarint(buffer);
+
+            // Only if the size is greater than zero, continue reading varInt. based on Glue Proto deserializer implementation
+            // Ref: https://tiny.amazon.com/1ru6rz8z/codeamazpackMaveblob1963thir
+            if (size > 0) {
+                for (int i = 0; i < size; i++) {
+                    ByteUtils.readVarint(buffer);
                 }
-                // Now the remaining data should be the actual protobuf message
-                LOGGER.debug("Finished skipping message indexes, parsing remaining data as protobuf");
-                return parser.parseFrom(codedInputStream);
             }
-
+            Message message = parser.parseFrom(buffer);
+            return type.cast(message);
         } catch (Exception e) {
-            throw new IOException("Failed to parse protobuf data with or without message index", e);
+            throw new IOException("Failed to deserialize Protobuf data.", e);
+        }
+    }
+
+
+    private <T> T glueDeserializer(byte[] data, Class<T> type) throws IOException {
+        try {
+
+            LOGGER.info("Using glueDeserializer");
+            CodedInputStream codedInputStream = CodedInputStream.newInstance(data);
+            Parser<Message> parser = (Parser<Message>) type.getMethod("parser").invoke(null);
+
+            // Seek one byte forward. Based on Glue Proto deserializer implementation
+            // Ref: https://tiny.amazon.com/1c9cadl8g/codeamazpackMaveblobcf94thir
+            codedInputStream.readUInt32();
+
+            Message message = parser.parseFrom(codedInputStream);
+            return type.cast(message);
+        } catch (Exception e) {
+            throw new IOException("Failed to deserialize Protobuf data.", e);
         }
     }
 }

--- a/powertools-kafka/src/main/java/software/amazon/lambda/powertools/kafka/serializers/KafkaProtobufDeserializer.java
+++ b/powertools-kafka/src/main/java/software/amazon/lambda/powertools/kafka/serializers/KafkaProtobufDeserializer.java
@@ -58,7 +58,7 @@ public class KafkaProtobufDeserializer extends AbstractKafkaDeserializer {
 
     private <T> T defaultDeserializer(byte[] data, Class<T> type) throws IOException {
         try {
-            LOGGER.info("Using default Protobuf deserializer");
+            LOGGER.debug("Using default Protobuf deserializer");
             Parser<Message> parser = (Parser<Message>) type.getMethod("parser").invoke(null);
             Message message = parser.parseFrom(data);
             return type.cast(message);
@@ -70,13 +70,12 @@ public class KafkaProtobufDeserializer extends AbstractKafkaDeserializer {
     private <T> T confluentDeserializer(byte[] data, Class<T> type) throws IOException {
         try {
 
-            LOGGER.info("Using confluentDeserializer");
+            LOGGER.debug("Using Confluent Deserializer");
             Parser<Message> parser = (Parser<Message>) type.getMethod("parser").invoke(null);
             ByteBuffer buffer = ByteBuffer.wrap(data);
             int size = ByteUtils.readVarint(buffer);
 
             // Only if the size is greater than zero, continue reading varInt. based on Glue Proto deserializer implementation
-            // Ref: https://tiny.amazon.com/1ru6rz8z/codeamazpackMaveblob1963thir
             if (size > 0) {
                 for (int i = 0; i < size; i++) {
                     ByteUtils.readVarint(buffer);
@@ -93,12 +92,11 @@ public class KafkaProtobufDeserializer extends AbstractKafkaDeserializer {
     private <T> T glueDeserializer(byte[] data, Class<T> type) throws IOException {
         try {
 
-            LOGGER.info("Using glueDeserializer");
+            LOGGER.debug("Using Glue Deserializer");
             CodedInputStream codedInputStream = CodedInputStream.newInstance(data);
             Parser<Message> parser = (Parser<Message>) type.getMethod("parser").invoke(null);
 
             // Seek one byte forward. Based on Glue Proto deserializer implementation
-            // Ref: https://tiny.amazon.com/1c9cadl8g/codeamazpackMaveblobcf94thir
             codedInputStream.readUInt32();
 
             Message message = parser.parseFrom(codedInputStream);

--- a/powertools-kafka/src/test/java/software/amazon/lambda/powertools/kafka/serializers/AbstractKafkaDeserializerTest.java
+++ b/powertools-kafka/src/test/java/software/amazon/lambda/powertools/kafka/serializers/AbstractKafkaDeserializerTest.java
@@ -462,7 +462,7 @@ class AbstractKafkaDeserializerTest {
     // Test implementation of AbstractKafkaDeserializer
     private static class TestDeserializer extends AbstractKafkaDeserializer {
         @Override
-        protected <T> T deserializeObject(byte[] data, Class<T> type) throws IOException {
+        protected <T> T deserializeObject(byte[] data, Class<T> type, SchemaRegistryType schemaRegistryType) throws IOException {
             return objectMapper.readValue(data, type);
         }
     }

--- a/powertools-kafka/src/test/java/software/amazon/lambda/powertools/kafka/serializers/KafkaAvroDeserializerTest.java
+++ b/powertools-kafka/src/test/java/software/amazon/lambda/powertools/kafka/serializers/KafkaAvroDeserializerTest.java
@@ -38,7 +38,7 @@ class KafkaAvroDeserializerTest {
         byte[] data = new byte[] { 1, 2, 3 };
 
         // When/Then
-        assertThatThrownBy(() -> deserializer.deserializeObject(data, String.class))
+        assertThatThrownBy(() -> deserializer.deserializeObject(data, String.class, AbstractKafkaDeserializer.SchemaRegistryType.NONE))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("Unsupported type for Avro deserialization");
     }
@@ -50,7 +50,7 @@ class KafkaAvroDeserializerTest {
         byte[] avroData = serializeAvro(product);
 
         // When
-        TestProduct result = deserializer.deserializeObject(avroData, TestProduct.class);
+        TestProduct result = deserializer.deserializeObject(avroData, TestProduct.class, AbstractKafkaDeserializer.SchemaRegistryType.NONE);
 
         // Then
         assertThat(result).isNotNull();
@@ -65,7 +65,7 @@ class KafkaAvroDeserializerTest {
         byte[] invalidAvroData = new byte[] { 1, 2, 3, 4, 5 };
 
         // When/Then
-        assertThatThrownBy(() -> deserializer.deserializeObject(invalidAvroData, TestProduct.class))
+        assertThatThrownBy(() -> deserializer.deserializeObject(invalidAvroData, TestProduct.class, AbstractKafkaDeserializer.SchemaRegistryType.NONE))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("Failed to deserialize Avro data");
     }

--- a/powertools-kafka/src/test/java/software/amazon/lambda/powertools/kafka/serializers/KafkaAvroDeserializerTest.java
+++ b/powertools-kafka/src/test/java/software/amazon/lambda/powertools/kafka/serializers/KafkaAvroDeserializerTest.java
@@ -38,9 +38,10 @@ class KafkaAvroDeserializerTest {
         byte[] data = new byte[] { 1, 2, 3 };
 
         // When/Then
-        assertThatThrownBy(() -> deserializer.deserializeObject(data, String.class, AbstractKafkaDeserializer.SchemaRegistryType.NONE))
-                .isInstanceOf(IOException.class)
-                .hasMessageContaining("Unsupported type for Avro deserialization");
+        assertThatThrownBy(() -> deserializer.deserializeObject(data, String.class,
+                AbstractKafkaDeserializer.SchemaRegistryType.NONE))
+                        .isInstanceOf(IOException.class)
+                        .hasMessageContaining("Unsupported type for Avro deserialization");
     }
 
     @Test
@@ -50,7 +51,8 @@ class KafkaAvroDeserializerTest {
         byte[] avroData = serializeAvro(product);
 
         // When
-        TestProduct result = deserializer.deserializeObject(avroData, TestProduct.class, AbstractKafkaDeserializer.SchemaRegistryType.NONE);
+        TestProduct result = deserializer.deserializeObject(avroData, TestProduct.class,
+                AbstractKafkaDeserializer.SchemaRegistryType.NONE);
 
         // Then
         assertThat(result).isNotNull();
@@ -65,9 +67,10 @@ class KafkaAvroDeserializerTest {
         byte[] invalidAvroData = new byte[] { 1, 2, 3, 4, 5 };
 
         // When/Then
-        assertThatThrownBy(() -> deserializer.deserializeObject(invalidAvroData, TestProduct.class, AbstractKafkaDeserializer.SchemaRegistryType.NONE))
-                .isInstanceOf(IOException.class)
-                .hasMessageContaining("Failed to deserialize Avro data");
+        assertThatThrownBy(() -> deserializer.deserializeObject(invalidAvroData, TestProduct.class,
+                AbstractKafkaDeserializer.SchemaRegistryType.NONE))
+                        .isInstanceOf(IOException.class)
+                        .hasMessageContaining("Failed to deserialize Avro data");
     }
 
 }

--- a/powertools-kafka/src/test/java/software/amazon/lambda/powertools/kafka/serializers/KafkaJsonDeserializerTest.java
+++ b/powertools-kafka/src/test/java/software/amazon/lambda/powertools/kafka/serializers/KafkaJsonDeserializerTest.java
@@ -42,7 +42,7 @@ class KafkaJsonDeserializerTest {
         byte[] data = new byte[] { 1, 2, 3 };
 
         // When/Then
-        assertThatThrownBy(() -> deserializer.deserializeObject(data, Object.class))
+        assertThatThrownBy(() -> deserializer.deserializeObject(data, Object.class, AbstractKafkaDeserializer.SchemaRegistryType.NONE))
                 .isInstanceOf(JsonParseException.class);
     }
 
@@ -53,7 +53,7 @@ class KafkaJsonDeserializerTest {
         byte[] jsonData = objectMapper.writeValueAsBytes(product);
 
         // When
-        TestProductPojo result = deserializer.deserializeObject(jsonData, TestProductPojo.class);
+        TestProductPojo result = deserializer.deserializeObject(jsonData, TestProductPojo.class, AbstractKafkaDeserializer.SchemaRegistryType.NONE);
 
         // Then
         assertThat(result).isNotNull();

--- a/powertools-kafka/src/test/java/software/amazon/lambda/powertools/kafka/serializers/KafkaJsonDeserializerTest.java
+++ b/powertools-kafka/src/test/java/software/amazon/lambda/powertools/kafka/serializers/KafkaJsonDeserializerTest.java
@@ -42,8 +42,9 @@ class KafkaJsonDeserializerTest {
         byte[] data = new byte[] { 1, 2, 3 };
 
         // When/Then
-        assertThatThrownBy(() -> deserializer.deserializeObject(data, Object.class, AbstractKafkaDeserializer.SchemaRegistryType.NONE))
-                .isInstanceOf(JsonParseException.class);
+        assertThatThrownBy(() -> deserializer.deserializeObject(data, Object.class,
+                AbstractKafkaDeserializer.SchemaRegistryType.NONE))
+                        .isInstanceOf(JsonParseException.class);
     }
 
     @Test
@@ -53,7 +54,8 @@ class KafkaJsonDeserializerTest {
         byte[] jsonData = objectMapper.writeValueAsBytes(product);
 
         // When
-        TestProductPojo result = deserializer.deserializeObject(jsonData, TestProductPojo.class, AbstractKafkaDeserializer.SchemaRegistryType.NONE);
+        TestProductPojo result = deserializer.deserializeObject(jsonData, TestProductPojo.class,
+                AbstractKafkaDeserializer.SchemaRegistryType.NONE);
 
         // Then
         assertThat(result).isNotNull();


### PR DESCRIPTION
**Issue #, if available:** N/A

## Description of changes:

Copy of https://github.com/aws-powertools/powertools-lambda-java/pull/1906

Thanks to @karthikpswamy for contributing this logic!

> ## Description of changes:
> 
>     * Adding support for different schema registry types (Confluent and Glue)
> 
>     * Improving the handling of message indices in protobuf data
> 
>     * Fixing deserialization logic for different schema registry formats
> 
>     * Adding appropriate tests for both Confluent and Glue schema registry scenarios
> 
> 
> Schema Registry Type Detection and Deserialization Logic:
> ### No Schema Registry Integration:
> 
>     * When KafkaEvent contains no key/value metadata
> 
>     * Uses entire byte array as raw data for deserialization
> 
>     * AWS Glue Schema Registry:
> 
> 
> ### Identified by 16-byte schema ID in key/value metadata
> 
>     * Skips first byte of data
> 
>     * Uses remaining bytes for Protobuf deserialization
> 
>     * Confluent Schema Registry:
> 
> 
> ### Default case when neither of above conditions are met
> 
>     * Follows Confluent wire format specification
> 
>     * Dynamically skips 1 or 2 bytes based on message index
> 
>     * Uses remaining bytes for Protobuf deserialization


**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)