### PR TITLE
 build(deps): Upgrade DynamoDBLocal to 2.6.0

### DIFF
--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -983,7 +983,7 @@ To unit test your function with DynamoDB Local, you can refer to this guide to [
         <dependency>
            <groupId>com.amazonaws</groupId>
            <artifactId>DynamoDBLocal</artifactId>
-           <version>[1.12,2.0)</version>
+           <version>2.6.0</version>
             <scope>test</scope>
         </dependency>
         <!-- Needed when building locally on M1 Mac -->

--- a/powertools-idempotency/powertools-idempotency-dynamodb/pom.xml
+++ b/powertools-idempotency/powertools-idempotency-dynamodb/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>DynamoDBLocal</artifactId>
-            <version>[1.12,2.0)</version>
+            <version>2.6.0</version>
             <scope>test</scope>
         </dependency>
         <!--Needed when building locally on M1 Mac-->


### PR DESCRIPTION
## Summary

This addresses alert https://github.com/aws-powertools/powertools-lambda-java/security/dependabot/65

`jetty-server` version is now larger than patched version:

```sh
❯ mvn dependency:tree | grep jetty-server
[INFO] |  +- org.eclipse.jetty:jetty-server:jar:12.0.14:test
```

### Changes

**Issue number:** https://github.com/aws-powertools/powertools-lambda-java/issues/1917

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.