### PR TITLE
build(deps): Upgrade logback to 1.5.18

### DIFF
--- a/powertools-logging/powertools-logging-logback/pom.xml
+++ b/powertools-logging/powertools-logging-logback/pom.xml
@@ -28,11 +28,11 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.7</version>
+            <version>1.5.18</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.sun.mail</groupId>
-                      <artifactId>javax.mail</artifactId>
+                    <artifactId>javax.mail</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
## Summary

Addressing https://github.com/aws-powertools/powertools-lambda-java/security/dependabot/66

Patched version is now in dependency tree:

```sh
❯ mvn dependency:tree | grep logback-core
[INFO] |  \- ch.qos.logback:logback-core:jar:1.5.18:compile
```

### Changes

**Issue number:** https://github.com/aws-powertools/powertools-lambda-java/issues/1917

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.