### PR TITLE
fix(examples): Fix GraalVM metadata after common runtime client changes

### DIFF
--- a/examples/powertools-examples-core-utilities/sam-graalvm/src/main/resources/META-INF/native-image/com.amazonaws/aws-lambda-java-runtime-interface-client/jni-config.json
+++ b/examples/powertools-examples-core-utilities/sam-graalvm/src/main/resources/META-INF/native-image/com.amazonaws/aws-lambda-java-runtime-interface-client/jni-config.json
@@ -4,8 +4,8 @@
     "methods":[{"name":"<init>","parameterTypes":["java.lang.String","int"] }]
   },
   {
-    "name":"com.amazonaws.services.lambda.runtime.api.client.runtimeapi.InvocationRequest",
-    "fields":[{"name":"id"}, {"name":"invokedFunctionArn"}, {"name":"deadlineTimeInMs"}, {"name":"xrayTraceId"}, {"name":"clientContext"}, {"name":"cognitoIdentity"}, {"name":"content"}],
+    "name":"com.amazonaws.services.lambda.runtime.api.client.runtimeapi.dto.InvocationRequest",
+    "fields":[{"name":"id"}, {"name":"invokedFunctionArn"}, {"name":"deadlineTimeInMs"}, {"name":"xrayTraceId"}, {"name":"clientContext"}, {"name":"cognitoIdentity"}, {"name": "tenantId"}, {"name":"content"}],
     "allPublicMethods":true
   }
 ]

--- a/examples/powertools-examples-core-utilities/sam-graalvm/src/main/resources/META-INF/native-image/com.amazonaws/aws-lambda-java-runtime-interface-client/reflect-config.json
+++ b/examples/powertools-examples-core-utilities/sam-graalvm/src/main/resources/META-INF/native-image/com.amazonaws/aws-lambda-java-runtime-interface-client/reflect-config.json
@@ -27,8 +27,8 @@
     "fields":[{"name":"theUnsafe"}]
   },
   {
-    "name":"com.amazonaws.services.lambda.runtime.api.client.runtimeapi.InvocationRequest",
-    "fields":[{"name":"id"}, {"name":"invokedFunctionArn"}, {"name":"deadlineTimeInMs"}, {"name":"xrayTraceId"}, {"name":"clientContext"}, {"name":"cognitoIdentity"}, {"name":"content"}],
+    "name":"com.amazonaws.services.lambda.runtime.api.client.runtimeapi.dto.InvocationRequest",
+    "fields":[{"name":"id"}, {"name":"invokedFunctionArn"}, {"name":"deadlineTimeInMs"}, {"name":"xrayTraceId"}, {"name":"clientContext"}, {"name":"cognitoIdentity"}, {"name": "tenantId"}, {"name":"content"}],
     "allPublicMethods":true
   }
 ]

--- a/examples/powertools-examples-core-utilities/sam-graalvm/src/main/resources/META-INF/native-image/com.amazonaws/aws-lambda-java-runtime-interface-client/resource-config.json
+++ b/examples/powertools-examples-core-utilities/sam-graalvm/src/main/resources/META-INF/native-image/com.amazonaws/aws-lambda-java-runtime-interface-client/resource-config.json
@@ -2,16 +2,16 @@
   "resources": {
     "includes": [
       {
-        "pattern": "\\Qaarch64/aws-lambda-runtime-interface-client.glibc.so\\E"
+        "pattern": "\\Qjni/libaws-lambda-jni.linux-aarch_64.so\\E"
       },
       {
-        "pattern": "\\Qaarch64/aws-lambda-runtime-interface-client.musl.so\\E"
+        "pattern": "\\Qjni/libaws-lambda-jni.linux-x86_64.so\\E"
       },
       {
-        "pattern": "\\Qx86_64/aws-lambda-runtime-interface-client.glibc.so\\E"
+        "pattern": "\\Qjni/libaws-lambda-jni.linux_musl-aarch_64.so\\E"
       },
       {
-        "pattern": "\\Qx86_64/aws-lambda-runtime-interface-client.musl.so\\E"
+        "pattern": "\\Qjni/libaws-lambda-jni.linux_musl-x86_64.so\\E"
       }
     ]
   },

--- a/examples/powertools-examples-parameters/sam-graalvm/src/main/resources/META-INF/native-image/com.amazonaws/aws-lambda-java-runtime-interface-client/jni-config.json
+++ b/examples/powertools-examples-parameters/sam-graalvm/src/main/resources/META-INF/native-image/com.amazonaws/aws-lambda-java-runtime-interface-client/jni-config.json
@@ -4,8 +4,8 @@
     "methods":[{"name":"<init>","parameterTypes":["java.lang.String","int"] }]
   },
   {
-    "name":"com.amazonaws.services.lambda.runtime.api.client.runtimeapi.InvocationRequest",
-    "fields":[{"name":"id"}, {"name":"invokedFunctionArn"}, {"name":"deadlineTimeInMs"}, {"name":"xrayTraceId"}, {"name":"clientContext"}, {"name":"cognitoIdentity"}, {"name":"content"}],
+    "name":"com.amazonaws.services.lambda.runtime.api.client.runtimeapi.dto.InvocationRequest",
+    "fields":[{"name":"id"}, {"name":"invokedFunctionArn"}, {"name":"deadlineTimeInMs"}, {"name":"xrayTraceId"}, {"name":"clientContext"}, {"name":"cognitoIdentity"}, {"name": "tenantId"}, {"name":"content"}],
     "allPublicMethods":true
   }
 ]

--- a/examples/powertools-examples-parameters/sam-graalvm/src/main/resources/META-INF/native-image/com.amazonaws/aws-lambda-java-runtime-interface-client/reflect-config.json
+++ b/examples/powertools-examples-parameters/sam-graalvm/src/main/resources/META-INF/native-image/com.amazonaws/aws-lambda-java-runtime-interface-client/reflect-config.json
@@ -27,8 +27,8 @@
     "fields":[{"name":"theUnsafe"}]
   },
   {
-    "name":"com.amazonaws.services.lambda.runtime.api.client.runtimeapi.InvocationRequest",
-    "fields":[{"name":"id"}, {"name":"invokedFunctionArn"}, {"name":"deadlineTimeInMs"}, {"name":"xrayTraceId"}, {"name":"clientContext"}, {"name":"cognitoIdentity"}, {"name":"content"}],
+    "name":"com.amazonaws.services.lambda.runtime.api.client.runtimeapi.dto.InvocationRequest",
+    "fields":[{"name":"id"}, {"name":"invokedFunctionArn"}, {"name":"deadlineTimeInMs"}, {"name":"xrayTraceId"}, {"name":"clientContext"}, {"name":"cognitoIdentity"}, {"name": "tenantId"}, {"name":"content"}],
     "allPublicMethods":true
   }
 ]

--- a/examples/powertools-examples-parameters/sam-graalvm/src/main/resources/META-INF/native-image/com.amazonaws/aws-lambda-java-runtime-interface-client/resource-config.json
+++ b/examples/powertools-examples-parameters/sam-graalvm/src/main/resources/META-INF/native-image/com.amazonaws/aws-lambda-java-runtime-interface-client/resource-config.json
@@ -2,16 +2,16 @@
   "resources": {
     "includes": [
       {
-        "pattern": "\\Qaarch64/aws-lambda-runtime-interface-client.glibc.so\\E"
+        "pattern": "\\Qjni/libaws-lambda-jni.linux-aarch_64.so\\E"
       },
       {
-        "pattern": "\\Qaarch64/aws-lambda-runtime-interface-client.musl.so\\E"
+        "pattern": "\\Qjni/libaws-lambda-jni.linux-x86_64.so\\E"
       },
       {
-        "pattern": "\\Qx86_64/aws-lambda-runtime-interface-client.glibc.so\\E"
+        "pattern": "\\Qjni/libaws-lambda-jni.linux_musl-aarch_64.so\\E"
       },
       {
-        "pattern": "\\Qx86_64/aws-lambda-runtime-interface-client.musl.so\\E"
+        "pattern": "\\Qjni/libaws-lambda-jni.linux_musl-x86_64.so\\E"
       }
     ]
   },


### PR DESCRIPTION
## Summary

With the introduction of #1927 there are some changes with regards to the native system libraries which break the existing examples in both:

- core-utilities (sam-graalvm)
- parameters (sam-graalvm)


### Changes

- Changed package name for InvocationRequest as it's now part of the `dto` sub package. 
- Added additional `tenantId` field to the InvocationRequest metadata
- Added references to the jni libraries in the correct path inside the jar 

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->


**Issue number:** #1934

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.