### PR TITLE
chore(ci): add new dependabot package ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
   - package-ecosystem: docker
     directories:
       - "/powertools-e2e-tests"
+      - "/examples"
     labels: [ ]
     schedule:
       interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,23 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: chore
+
+  - package-ecosystem: docker
+    directories:
+      - "/powertools-e2e-tests"
+    labels: [ ]
+    schedule:
+      interval: daily
+
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     labels:
       - "maven"
       - "dependencies"


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

This PR adds support for new package ecosystems in dependabot, namely docker and github actions. This will ensure all gh actions are up to date and allow you to use images with sha digest in Dockerfile.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** #1947 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.