### PR TITLE
chore(ci): Add Docker paths via globs to dependabot and update Dockerfiles to pin sha256

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,12 @@ updates:
 
   - package-ecosystem: docker
     directories:
-      - "/powertools-e2e-tests"
-      - "/examples"
-    labels: [ ]
+      - "/powertools-e2e-tests/src/test/resources/docker"
+      - "/docs"
+      - "/examples/**"
     schedule:
       interval: daily
+    labels: [ ]
 
   - package-ecosystem: "maven"
     directory: "/"

--- a/examples/powertools-examples-core-utilities/sam-graalvm/Dockerfile
+++ b/examples/powertools-examples-core-utilities/sam-graalvm/Dockerfile
@@ -1,5 +1,5 @@
 #Use the official AWS SAM base image for Java 21
-FROM public.ecr.aws/sam/build-java21:latest
+FROM public.ecr.aws/sam/build-java21@sha256:a5554d68374e19450c6c88448516ac95a9acedc779f318040f5c230134b4e461
 
 #Install GraalVM dependencies
 RUN curl -4 -L curl https://download.oracle.com/graalvm/21/latest/graalvm-jdk-21_linux-x64_bin.tar.gz | tar -xvz

--- a/examples/powertools-examples-parameters/sam-graalvm/Dockerfile
+++ b/examples/powertools-examples-parameters/sam-graalvm/Dockerfile
@@ -1,5 +1,5 @@
 #Use the official AWS SAM base image for Java 21
-FROM public.ecr.aws/sam/build-java21:latest
+FROM public.ecr.aws/sam/build-java21@sha256:a5554d68374e19450c6c88448516ac95a9acedc779f318040f5c230134b4e461
 
 #Install GraalVM dependencies
 RUN curl -4 -L curl https://download.oracle.com/graalvm/21/latest/graalvm-jdk-21_linux-x64_bin.tar.gz | tar -xvz

--- a/examples/powertools-examples-serialization/sam-graalvm/Dockerfile
+++ b/examples/powertools-examples-serialization/sam-graalvm/Dockerfile
@@ -1,5 +1,5 @@
 #Use the official AWS SAM base image for Java 21
-FROM public.ecr.aws/sam/build-java21:latest
+FROM public.ecr.aws/sam/build-java21@sha256:a5554d68374e19450c6c88448516ac95a9acedc779f318040f5c230134b4e461
 
 #Install GraalVM dependencies
 RUN curl -4 -L curl https://download.oracle.com/graalvm/21/latest/graalvm-jdk-21_linux-x64_bin.tar.gz | tar -xvz


### PR DESCRIPTION
## Summary
Updates the paths in dependabot.yaml using globs to reference the `Dockerfile`s in the `examples` folder. Also adds other Dockerfiles.

According to the dependabot docs globs are supported: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#defining-multiple-locations-for-manifest-files

### Changes

Follow-up of https://github.com/aws-powertools/powertools-lambda-java/pull/1948.

**Issue number:** https://github.com/aws-powertools/powertools-lambda-java/issues/1947

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.