### PR TITLE
fix(parameters): Correctly check for empty values in AppConfig Parameters Provider.

### DIFF
--- a/powertools-parameters/powertools-parameters-appconfig/src/main/java/software/amazon/lambda/powertools/parameters/appconfig/AppConfigProvider.java
+++ b/powertools-parameters/powertools-parameters-appconfig/src/main/java/software/amazon/lambda/powertools/parameters/appconfig/AppConfigProvider.java
@@ -16,6 +16,8 @@ package software.amazon.lambda.powertools.parameters.appconfig;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.appconfigdata.AppConfigDataClient;
 import software.amazon.awssdk.services.appconfigdata.model.GetLatestConfigurationRequest;
 import software.amazon.awssdk.services.appconfigdata.model.GetLatestConfigurationResponse;
@@ -47,7 +49,7 @@ public class AppConfigProvider extends BaseProvider {
     private final HashMap<String, EstablishedSession> establishedSessions = new HashMap<>();
 
     AppConfigProvider(CacheManager cacheManager, TransformationManager transformationManager,
-                      AppConfigDataClient client, String environment, String application) {
+            AppConfigDataClient client, String environment, String application) {
         super(cacheManager, transformationManager);
         this.client = client;
         this.application = application;
@@ -63,7 +65,6 @@ public class AppConfigProvider extends BaseProvider {
         return new AppConfigProviderBuilder();
     }
 
-
     /**
      * Retrieve the parameter value from the AppConfig parameter store.<br />
      *
@@ -76,13 +77,12 @@ public class AppConfigProvider extends BaseProvider {
         // so that we can the initial token. If we already have a session, we can take
         // the next request token from there.
         EstablishedSession establishedSession = establishedSessions.getOrDefault(key, null);
-        String sessionToken = establishedSession != null ?
-                establishedSession.nextSessionToken :
-                client.startConfigurationSession(StartConfigurationSessionRequest.builder()
-                                .applicationIdentifier(this.application)
-                                .environmentIdentifier(this.environment)
-                                .configurationProfileIdentifier(key)
-                                .build())
+        String sessionToken = establishedSession != null ? establishedSession.nextSessionToken
+                : client.startConfigurationSession(StartConfigurationSessionRequest.builder()
+                        .applicationIdentifier(this.application)
+                        .environmentIdentifier(this.environment)
+                        .configurationProfileIdentifier(key)
+                        .build())
                         .initialConfigurationToken();
 
         // Get the configuration using the token
@@ -93,16 +93,18 @@ public class AppConfigProvider extends BaseProvider {
         // Get the next session token we'll use next time we are asked for this key
         String nextSessionToken = response.nextPollConfigurationToken();
 
-        // Get the value of the key. Note that AppConfig will return null if the value
-        // has not changed since we last asked for it in this session - in this case
-        // we return the value we stashed at last request.
-        String value = response.configuration() != null ?
-                response.configuration().asUtf8String() : // if we have a new value, use it
-                establishedSession != null ?
-                        establishedSession.lastConfigurationValue :
-                        // if we don't but we have a previous value, use that
-                        null; // otherwise we've got no value
-
+        // Get the value of the key. Note that AppConfig will return an empty value if the configuration has not changed
+        // since we last asked for it in this session - in this case we return the value we stashed at last request.
+        // https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-code-samples-using-API-read-configuration.html
+        SdkBytes configFromApi = response.configuration();
+        String value;
+        if (configFromApi != null && configFromApi.asByteArray().length != 0) {
+            value = configFromApi.asUtf8String();
+        } else if (establishedSession != null) {
+            value = establishedSession.lastConfigurationValue;
+        } else {
+            value = null;
+        }
         // Update the cache so we can get the next value later
         establishedSessions.put(key, new EstablishedSession(nextSessionToken, value));
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where the AppConfig Provider wrongly returns null. AppConfig returns an empty byte array on `GetLatestConfigurationChange` if there was no change since the session was established. It is not sufficient to perform a null check but rather we should check if the byte array is of length zero.

This PR is similar to https://github.com/aws-powertools/powertools-lambda-java/pull/1673 against v1 but was not migrated correctly to v2.

Related docs: https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-code-samples-using-API-read-configuration.html

Also resolves existing Sonarcube linting errors where possible.

### Changes

**Issue number:** https://github.com/aws-powertools/powertools-lambda-java/issues/1981

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.