### PR TITLE
docs(examples): Enable end to end tracing for SQS batch example.

### DIFF
--- a/examples/powertools-examples-batch/deploy/sqs/template.yml
+++ b/examples/powertools-examples-batch/deploy/sqs/template.yml
@@ -65,6 +65,7 @@ Resources:
   DemoSQSSenderFunction:
     Type: AWS::Serverless::Function
     Properties:
+      Tracing: Active
       CodeUri: ../..
       Handler: org.demo.batch.sqs.SqsBatchSender::handleRequest
       Environment:
@@ -173,7 +174,6 @@ Resources:
               Action:
                 - s3:PutObject
               Resource: !Sub ${Bucket.Arn}/*
-
       Events:
         MySQSEvent:
           Type: SQS

--- a/examples/powertools-examples-batch/src/main/java/org/demo/batch/sqs/AbstractSqsBatchHandler.java
+++ b/examples/powertools-examples-batch/src/main/java/org/demo/batch/sqs/AbstractSqsBatchHandler.java
@@ -14,21 +14,22 @@
 
 package org.demo.batch.sqs;
 
-import com.amazonaws.services.lambda.runtime.Context;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
+
 import org.demo.batch.model.Product;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.tracing.Tracing;
 import software.amazon.lambda.powertools.tracing.TracingUtils;
 
@@ -43,7 +44,6 @@ public class AbstractSqsBatchHandler {
      * Simulate some processing (I/O + S3 put request)
      * @param p deserialized product
      */
-    @Logging
     @Tracing
     protected void processMessage(Product p) {
         TracingUtils.putAnnotation("productId", p.getId());
@@ -51,15 +51,16 @@ public class AbstractSqsBatchHandler {
         MDC.put("product", String.valueOf(p.getId()));
         LOGGER.info("Processing product {}", p);
 
-        char c = (char)(r.nextInt(26) + 'a');
+        char c = (char) (r.nextInt(26) + 'a');
         char[] chars = new char[1024 * 1000];
         Arrays.fill(chars, c);
         p.setName(new String(chars));
         try {
-            File file = new File("/tmp/"+p.getId()+".json");
+            File file = new File("/tmp/" + p.getId() + ".json");
             mapper.writeValue(file, p);
             s3.putObject(
-                    PutObjectRequest.builder().bucket(bucket).key(p.getId()+".json").build(), RequestBody.fromFile(file));
+                    PutObjectRequest.builder().bucket(bucket).key(p.getId() + ".json").build(),
+                    RequestBody.fromFile(file));
         } catch (IOException e) {
             throw new RuntimeException(e);
         } finally {


### PR DESCRIPTION
## Summary

The SQS Batch example was missing `Tracing: Active` on the SQS sender. This caused no trace_id to be propagated from the sender through the chain which is why the traces were not showing up in X-RAY.

Also removed wrongly placed `@Logging` annotation.

### Changes

**Issue number:** https://github.com/aws-powertools/powertools-lambda-java/issues/1994

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.