### PR TITLE
chore(ci): Improve reliability of retries in TracingE2ET

### DIFF
--- a/powertools-e2e-tests/pom.xml
+++ b/powertools-e2e-tests/pom.xml
@@ -151,6 +151,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
             <scope>compile</scope>

--- a/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/testutils/RetryUtils.java
+++ b/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/testutils/RetryUtils.java
@@ -47,7 +47,21 @@ public final class RetryUtils {
      */
     @SafeVarargs
     public static Retry createRetry(String name, Class<? extends Throwable>... retryOnThrowables) {
-        RetryConfig config = RetryConfig.from(DEFAULT_RETRY_CONFIG)
+        return createRetry(name, DEFAULT_RETRY_CONFIG, retryOnThrowables);
+    }
+
+    /**
+     * Creates a retry instance with custom configuration for the specified throwable types.
+     * 
+     * @param name the name for the retry instance
+     * @param customConfig the custom retry configuration
+     * @param retryOnThrowables the throwable classes to retry on
+     * @return configured Retry instance
+     */
+    @SafeVarargs
+    public static Retry createRetry(String name, RetryConfig customConfig,
+            Class<? extends Throwable>... retryOnThrowables) {
+        RetryConfig config = RetryConfig.from(customConfig)
                 .retryExceptions(retryOnThrowables)
                 .build();
 
@@ -70,6 +84,22 @@ public final class RetryUtils {
     public static <T> Supplier<T> withRetry(Supplier<T> supplier, String name,
             Class<? extends Throwable>... retryOnThrowables) {
         Retry retry = createRetry(name, retryOnThrowables);
+        return Retry.decorateSupplier(retry, supplier);
+    }
+
+    /**
+     * Decorates a supplier with custom retry logic for the specified throwable types.
+     * 
+     * @param supplier the supplier to decorate
+     * @param name the name for the retry instance
+     * @param customConfig the custom retry configuration
+     * @param retryOnThrowables the throwable classes to retry on
+     * @return decorated supplier with retry logic
+     */
+    @SafeVarargs
+    public static <T> Supplier<T> withRetry(Supplier<T> supplier, String name, RetryConfig customConfig,
+            Class<? extends Throwable>... retryOnThrowables) {
+        Retry retry = createRetry(name, customConfig, retryOnThrowables);
         return Retry.decorateSupplier(retry, supplier);
     }
 }

--- a/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/testutils/metrics/MetricsFetcher.java
+++ b/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/testutils/metrics/MetricsFetcher.java
@@ -14,7 +14,6 @@
 
 package software.amazon.lambda.powertools.testutils.metrics;
 
-import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -75,9 +74,8 @@ public class MetricsFetcher {
             LOG.debug("Get Metrics for namespace {}, start {}, end {}, metric {}, dimensions {}", namespace, start,
                     end, metricName, dimensionsList);
             GetMetricDataResponse metricData = cloudwatch.getMetricData(GetMetricDataRequest.builder()
-                    // Add 1 minute padding around start and end time to account time imprecisions
-                    .startTime(start.minus(Duration.ofMinutes(1)))
-                    .endTime(end.plus(Duration.ofMinutes(1)))
+                    .startTime(start)
+                    .endTime(end)
                     .metricDataQueries(MetricDataQuery.builder()
                             .id(metricName.toLowerCase(Locale.ROOT))
                             .metricStat(MetricStat.builder()

--- a/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/testutils/metrics/MetricsFetcher.java
+++ b/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/testutils/metrics/MetricsFetcher.java
@@ -14,6 +14,7 @@
 
 package software.amazon.lambda.powertools.testutils.metrics;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -74,8 +75,9 @@ public class MetricsFetcher {
             LOG.debug("Get Metrics for namespace {}, start {}, end {}, metric {}, dimensions {}", namespace, start,
                     end, metricName, dimensionsList);
             GetMetricDataResponse metricData = cloudwatch.getMetricData(GetMetricDataRequest.builder()
-                    .startTime(start)
-                    .endTime(end)
+                    // Add 1 minute padding around start and end time to account time imprecisions
+                    .startTime(start.minus(Duration.ofMinutes(1)))
+                    .endTime(end.plus(Duration.ofMinutes(1)))
                     .metricDataQueries(MetricDataQuery.builder()
                             .id(metricName.toLowerCase(Locale.ROOT))
                             .metricStat(MetricStat.builder()

--- a/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/testutils/tracing/TraceFetcher.java
+++ b/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/testutils/tracing/TraceFetcher.java
@@ -109,6 +109,7 @@ public class TraceFetcher {
         if (!tracesResponse.hasTraces()) {
             throw new TraceNotFoundException(String.format("No trace found for traceIds %s", traceIds));
         }
+        
         Trace traceRes = new Trace();
         tracesResponse.traces().forEach(trace -> {
             if (trace.hasSegments()) {
@@ -116,6 +117,7 @@ public class TraceFetcher {
                     try {
                         SegmentDocument document = MAPPER.readValue(segment.document(), SegmentDocument.class);
                         if ("AWS::Lambda::Function".equals(document.getOrigin()) && document.hasSubsegments()) {
+                            LOG.debug("Populating subsegments for document {}", MAPPER.writeValueAsString(document));
                             getNestedSubSegments(document.getSubsegments(), traceRes, Collections.emptyList());
                         } else if ("AWS::Lambda::Function".equals(document.getOrigin())) {
                             LOG.debug(
@@ -133,6 +135,7 @@ public class TraceFetcher {
                 throw new TraceNotFoundException(String.format("No segments found in trace %s", trace.id()));
             }
         });
+
         return traceRes;
     }
 


### PR DESCRIPTION
## Summary

This PR addresses two reliability issues of the TracingE2E tests which were failing occasionally:

1. The search horizon was too narrow. When the trace started at the end of minute x and some subsegments got populated in minute y, they were not found. I added a one minute padding to the search horizon.
2. After finding trace ids for the search, we immediately attempted to fetch the (sub-)segments of that trace without accounting for that fact that they are populated async with a delay. I added retries for the second query for the sub-segments as well. See comment https://github.com/aws-powertools/powertools-lambda-java/issues/1846#issuecomment-3160493455

Also adds some more debug logs and more useful logging statements to make debugging easier in the future.

### Changes

**Issue number:** https://github.com/aws-powertools/powertools-lambda-java/issues/1846

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.