### PR TITLE
docs: Rename wrong POWERTOOLS_DISABLE_METRICS to correct POWERTOOLS_M…

### DIFF
--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -540,7 +540,7 @@ The following example shows how to configure a custom `Metrics` Singleton using 
 
 ### Suppressing metrics output
 
-If you would like to suppress metrics output during your unit tests, you can use the `POWERTOOLS_DISABLE_METRICS` environment variable. For example, using Maven you can set in your build plugins:
+If you would like to suppress metrics output during your unit tests, you can use the `POWERTOOLS_METRICS_DISABLED` environment variable. For example, using Maven you can set in your build plugins:
 
 ```xml
 <plugin>
@@ -548,7 +548,7 @@ If you would like to suppress metrics output during your unit tests, you can use
     <artifactId>maven-surefire-plugin</artifactId>
     <configuration>
         <environmentVariables>
-            <POWERTOOLS_DISABLE_METRICS>true</POWERTOOLS_DISABLE_METRICS>
+            <POWERTOOLS_METRICS_DISABLED>true</POWERTOOLS_METRICS_DISABLED>
         </environmentVariables>
     </configuration>
 </plugin>

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ Powertools for AWS Lambda (Java) is a suite of utilities for AWS Lambda Function
 
 
 ???+ tip "Looking for a quick run through of the core utilities?"
-    Check out [this detailed blog post](https://aws.amazon.com/blogs/opensource/simplifying-serverless-best-practices-with-aws-lambda-powertools-java/) with a practical example. To dive deeper, 
+    Check out [this detailed blog post](https://aws.amazon.com/blogs/compute/introducing-v2-of-powertools-for-aws-lambda-java/) with a practical example. To dive deeper, 
     the [Powertools for AWS Lambda (Java) workshop](https://catalog.us-east-1.prod.workshops.aws/workshops/a7011c82-e4af-4a52-80fa-fcd61f1dacd9/en-US/introduction) is a great next step.
 
 ## Tenets


### PR DESCRIPTION
## Summary

This PR fixes a small typo in the metrics documentation where the environment variable name for disabling metrics flushing was incorrect.

Also updates the link in index.md to the most recent blog post.

### Changes

**Issue number:** https://github.com/aws-powertools/powertools-lambda-java/issues/2019

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.