### PR TITLE
chore(ci): Remove non-PR triggers for verify dependencies workflow.

### DIFF
--- a/.github/workflows/security-dependencies-check.yml
+++ b/.github/workflows/security-dependencies-check.yml
@@ -6,20 +6,12 @@
 #
 # Triggers:
 #   - pull_request
-#   - push
-#   - workflow_dispatch
-#   - cron: daily at 12:00PM
 
 on:
-  pull_request: 
-  workflow_dispatch:
-  push:
-    branches: [ main ]
-  schedule:
-    - cron: '0 12 * * *' # Run daily at 12:00 UTC
+  pull_request:
 
 name: Verify Dependencies
-run-name: Verify Dependencies – ${{ github.event_name }}
+run-name: Verify Dependencies – ${{ github.event_name }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

This PR removes all non-PR triggers from the Verify Dependencies workflow. Those are not necessary since the main branch is protected and all checks are run (and commented by the bot) on a Pull Request.

### Changes

**Issue number:** https://github.com/aws-powertools/powertools-lambda-java/issues/1909

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.