### PR TITLE
chore(ci): Fix issue where docs were released with old version during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,6 +272,9 @@ jobs:
       - id: checkout
         name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          # Checkout PR branch to make sure we build the version-bumped docs
+          ref: ci-${{ github.run_id }}
       - name: Build
         run: |
           mkdir -p dist


### PR DESCRIPTION
## Summary

This PR fixes a small issue where the documentation version during the release workflow was not correctly deployed. We checked out the old repository code instead of the code of the version bump PR.

### Changes

**Issue number:** https://github.com/aws-powertools/powertools-lambda-java/issues/1911

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.