### PR TITLE
chore(ci): Fix circular dependency in dynamodb-local and maven packaging phases

### DIFF
--- a/powertools-idempotency/powertools-idempotency-dynamodb/pom.xml
+++ b/powertools-idempotency/powertools-idempotency-dynamodb/pom.xml
@@ -186,6 +186,9 @@
                         <configuration>
                             <includeScope>test</includeScope>
                             <excludeTransitive>false</excludeTransitive>
+                            <!-- MDEP-187: Avoids Maven phase circular dependency by not trying to copy unpacked reactor
+                            artifacts (powertools-idempotency-core)  -->
+                            <excludeGroupIds>software.amazon.lambda</excludeGroupIds>
                             <outputDirectory>${project.build.directory}/dynamodb-local</outputDirectory>
                         </configuration>
                     </execution>


### PR DESCRIPTION
## Summary

This PR address a small issue where a circular dependency in Maven phases caused build issues for the idempotency utility when attempting to start dynamodb-local before unit tests on an initial `mvn -B test` command. 

The issue is:
- Maven tries to copy all artifacts to `${project.build.directory}/dynamodb-local` before running unit tests.
- However, at this time the production dependencies are not yet built (`powertools-idempotency-core`)
- Maven cannot copy the artifacts of non-built `powertools-idempotency-core` and fails

Solution:
- `powertools-idempotency-core` is not needed for DynamoDB local which is treated as an external process. Removing it solves the circular dependency.

Example failure: https://github.com/aws-powertools/powertools-lambda-java/actions/runs/17577454233/job/49925991193

### Changes

**Issue number:** https://github.com/aws-powertools/powertools-lambda-java/issues/2128

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.