### PR TITLE
chore(ci): Skip maven deployment for e2e test handlers.

### DIFF
--- a/powertools-e2e-tests/handlers/pom.xml
+++ b/powertools-e2e-tests/handlers/pom.xml
@@ -13,7 +13,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-
         <lambda.java.core>1.3.0</lambda.java.core>
         <lambda.java.serialization>1.1.6</lambda.java.serialization>
         <lambda.java.events>3.16.1</lambda.java.events>
@@ -22,6 +21,7 @@
         <maven.compiler.version>3.14.0</maven.compiler.version>
         <aws.sdk.version>2.33.2</aws.sdk.version>
         <aspectj.version>1.9.20.1</aspectj.version>
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
 
     <modules>


### PR DESCRIPTION
## Summary

We need to skip publishing e2e handlers to Maven central. These were recently added to the parent pom to fix a bug where they were ignored in version bumping.

### Changes

**Issue number:** https://github.com/aws-powertools/powertools-lambda-java/issues/2130

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.