### PR TITLE
chore(ci): Do not use Mockito SNAPSHOT version for release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -536,6 +536,12 @@
     <profiles>
         <profile>
             <id>release</id>
+            <!-- TODO: Revert once 5.19.1 is stable released. -->
+            <!-- https://github.com/aws-powertools/powertools-lambda-java/issues/2079 -->
+            <properties>
+                <mockito.version>5.19.0</mockito.version>
+                <mockito-junit-jupiter.version>5.19.0</mockito-junit-jupiter.version>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -637,6 +643,7 @@
                 </plugins>
             </build>
         </profile>
+
     </profiles>
 
 </project>


### PR DESCRIPTION
## Summary

This PR temporarily disables the mockito snapshot version for releases which is OK since it is only a test dependency and will not be included in the release artifact.

Related issue tracks reverting this change once Mockito is stable released.

Failing publish: https://github.com/aws-powertools/powertools-lambda-java/actions/runs/17580625430/job/49936626887

### Changes

**Issue number:** https://github.com/aws-powertools/powertools-lambda-java/issues/2079

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.