### PR TITLE
chore(ci): Set mockito SNAPSHOT version only for Graal profiles.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,8 +114,8 @@
         <aws.sdk.v1.version>1.12.781</aws.sdk.v1.version>
         <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
         <elastic.version>1.7.0</elastic.version>
-        <mockito.version>5.19.1-SNAPSHOT</mockito.version>
-        <mockito-junit-jupiter.version>5.19.1-SNAPSHOT</mockito-junit-jupiter.version>
+        <mockito.version>5.19.0</mockito.version>
+        <mockito-junit-jupiter.version>5.19.0</mockito-junit-jupiter.version>
         <junit-pioneer.version>2.3.0</junit-pioneer.version>
         <crac.version>1.5.0</crac.version>
 
@@ -643,7 +643,21 @@
                 </plugins>
             </build>
         </profile>
-
+        <profile>
+            <id>generate-graalvm-files</id>
+            <properties>
+                <mockito.version>5.19.1-SNAPSHOT</mockito.version>
+                <mockito-junit-jupiter.version>5.19.1-SNAPSHOT</mockito-junit-jupiter.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>graalvm-native</id>
+            <properties>
+                <mockito.version>5.19.1-SNAPSHOT</mockito.version>
+                <mockito-junit-jupiter.version>5.19.1-SNAPSHOT</mockito-junit-jupiter.version>
+            </properties>
+        </profile>
+        
     </profiles>
 
 </project>


### PR DESCRIPTION
## Summary

The publish task still fails after https://github.com/aws-powertools/powertools-lambda-java/pull/2137. We cannot have the SNAPSHOT version in the default Maven profile. 

https://github.com/aws-powertools/powertools-lambda-java/actions/runs/17581345159/job/49938824194

### Changes

**Issue number:** https://github.com/aws-powertools/powertools-lambda-java/issues/2079

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.