### PR TITLE
feat: add automatic TenantId logging to Logger default properties

### DIFF
--- a/powertools-common/src/test/java/software/amazon/lambda/powertools/common/stubs/TestLambdaContext.java
+++ b/powertools-common/src/test/java/software/amazon/lambda/powertools/common/stubs/TestLambdaContext.java
@@ -74,4 +74,9 @@ public class TestLambdaContext implements Context {
     public LambdaLogger getLogger() {
         return null;
     }
+
+    @Override
+    public String getTenantId() {
+        return "test-tenant";
+    }
 }

--- a/powertools-logging/powertools-logging-log4j/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/PowertoolsResolver.java
+++ b/powertools-logging/powertools-logging-log4j/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/PowertoolsResolver.java
@@ -192,7 +192,7 @@ final class PowertoolsResolver implements EventResolver {
         public boolean isResolvable(LogEvent logEvent) {
             final String tenantId =
                     logEvent.getContextData().getValue(PowertoolsLoggedFields.TENANT_ID.getName());
-            return null != tenantId;
+            return null != tenantId && !tenantId.isEmpty();
         }
 
         @Override

--- a/powertools-logging/powertools-logging-log4j/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/PowertoolsResolver.java
+++ b/powertools-logging/powertools-logging-log4j/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/PowertoolsResolver.java
@@ -25,6 +25,7 @@ import static software.amazon.lambda.powertools.logging.internal.PowertoolsLogge
 import static software.amazon.lambda.powertools.logging.internal.PowertoolsLoggedFields.FUNCTION_VERSION;
 import static software.amazon.lambda.powertools.logging.internal.PowertoolsLoggedFields.SAMPLING_RATE;
 import static software.amazon.lambda.powertools.logging.internal.PowertoolsLoggedFields.SERVICE;
+import static software.amazon.lambda.powertools.logging.internal.PowertoolsLoggedFields.TENANT_ID;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -186,6 +187,23 @@ final class PowertoolsResolver implements EventResolver {
         }
     };
 
+    private static final EventResolver TENANT_ID_RESOLVER = new EventResolver() {
+        @Override
+        public boolean isResolvable(LogEvent logEvent) {
+            final String tenantId =
+                    logEvent.getContextData().getValue(PowertoolsLoggedFields.TENANT_ID.getName());
+            return null != tenantId;
+        }
+
+        @Override
+        public void resolve(LogEvent logEvent, JsonWriter jsonWriter) {
+            final String tenantId =
+                    logEvent.getContextData().getValue(PowertoolsLoggedFields.TENANT_ID.getName());
+            jsonWriter.writeString(tenantId);
+        }
+    };
+
+
     @SuppressWarnings("java:S106")
     private static final EventResolver NON_POWERTOOLS_FIELD_RESOLVER =
             (LogEvent logEvent, JsonWriter jsonWriter) -> {
@@ -233,6 +251,7 @@ final class PowertoolsResolver implements EventResolver {
                     { FUNCTION_TRACE_ID.getName(), XRAY_TRACE_RESOLVER },
                     { CORRELATION_ID.getName(), CORRELATION_ID_RESOLVER },
                     { SAMPLING_RATE.getName(), SAMPLING_RATE_RESOLVER },
+                    { TENANT_ID.getName(), TENANT_ID_RESOLVER },
                     { "region", REGION_RESOLVER },
                     { "account_id", ACCOUNT_ID_RESOLVER }
             }).collect(Collectors.toMap(data -> (String) data[0], data -> (EventResolver) data[1])));

--- a/powertools-logging/powertools-logging-log4j/src/main/resources/LambdaEcsLayout.json
+++ b/powertools-logging/powertools-logging-log4j/src/main/resources/LambdaEcsLayout.json
@@ -87,6 +87,10 @@
     "$resolver": "powertools",
     "field": "correlation_id"
   },
+  "tenant.id": {
+    "$resolver": "powertools",
+    "field": "tenant_id"
+  },
   "": {
     "$resolver": "powertools"
   }

--- a/powertools-logging/powertools-logging-log4j/src/main/resources/LambdaJsonLayout.json
+++ b/powertools-logging/powertools-logging-log4j/src/main/resources/LambdaJsonLayout.json
@@ -69,6 +69,10 @@
     "$resolver": "powertools",
     "field": "correlation_id"
   },
+  "tenant_id": {
+    "$resolver": "powertools",
+    "field": "tenant_id"
+  },
   "": {
     "$resolver": "powertools"
   }

--- a/powertools-logging/powertools-logging-log4j/src/test/java/org/apache/logging/log4j/layout/template/json/resolver/PowerToolsResolverFactoryTest.java
+++ b/powertools-logging/powertools-logging-log4j/src/test/java/org/apache/logging/log4j/layout/template/json/resolver/PowerToolsResolverFactoryTest.java
@@ -79,7 +79,9 @@ class PowerToolsResolverFactoryTest {
         File logFile = new File("target/logfile.json");
         assertThat(contentOf(logFile)).contains(
                 "{\"level\":\"DEBUG\",\"message\":\"Test debug event\",\"cold_start\":true,\"function_arn\":\"arn:aws:lambda:us-east-1:123456789012:function:test\",\"function_memory_size\":128,\"function_name\":\"test-function\",\"function_request_id\":\"test-request-id\",\"function_version\":\"1\",\"service\":\"testLog4j\",\"timestamp\":")
-                .contains("\"xray_trace_id\":\"1-63441c4a-abcdef012345678912345678\",\"myKey\":\"myValue\"}\n");
+            .contains("\"xray_trace_id\":\"1-63441c4a-abcdef012345678912345678\"")
+            .contains("\"tenant_id\":\"test-tenant\"")
+            .contains("\"myKey\":\"myValue\"");
     }
 
     @Test
@@ -89,7 +91,9 @@ class PowerToolsResolverFactoryTest {
 
         File logFile = new File("target/ecslogfile.json");
         assertThat(contentOf(logFile)).contains(
-                "\"ecs.version\":\"1.2.0\",\"log.level\":\"DEBUG\",\"message\":\"Test debug event\",\"service.name\":\"testLog4j\",\"service.version\":\"1\",\"log.logger\":\"software.amazon.lambda.powertools.logging.internal.handler.PowertoolsLogEnabled\",\"process.thread.name\":\"main\",\"cloud.provider\":\"aws\",\"cloud.service.name\":\"lambda\",\"cloud.region\":\"eu-central-1\",\"cloud.account.id\":\"123456789012\",\"faas.id\":\"arn:aws:lambda:us-east-1:123456789012:function:test\",\"faas.name\":\"test-function\",\"faas.version\":\"1\",\"faas.memory\":128,\"faas.execution\":\"test-request-id\",\"faas.coldstart\":true,\"trace.id\":\"1-63441c4a-abcdef012345678912345678\",\"myKey\":\"myValue\"}\n");
+            "\"ecs.version\":\"1.2.0\",\"log.level\":\"DEBUG\",\"message\":\"Test debug event\",\"service.name\":\"testLog4j\",\"service.version\":\"1\",\"log.logger\":\"software.amazon.lambda.powertools.logging.internal.handler.PowertoolsLogEnabled\",\"process.thread.name\":\"main\",\"cloud.provider\":\"aws\",\"cloud.service.name\":\"lambda\",\"cloud.region\":\"eu-central-1\",\"cloud.account.id\":\"123456789012\",\"faas.id\":\"arn:aws:lambda:us-east-1:123456789012:function:test\",\"faas.name\":\"test-function\",\"faas.version\":\"1\",\"faas.memory\":128,\"faas.execution\":\"test-request-id\",\"faas.coldstart\":true,\"trace.id\":\"1-63441c4a-abcdef012345678912345678\"")
+            .contains("\"tenant.id\":\"test-tenant\"")
+            .contains("\"myKey\":\"myValue\"");
     }
 
 }

--- a/powertools-logging/powertools-logging-logback/src/main/java/software/amazon/lambda/powertools/logging/logback/LambdaEcsEncoder.java
+++ b/powertools-logging/powertools-logging-logback/src/main/java/software/amazon/lambda/powertools/logging/logback/LambdaEcsEncoder.java
@@ -173,7 +173,7 @@ public class LambdaEcsEncoder extends EncoderBase<ILoggingEvent> {
             }
             
             String tenantId = mdcPropertyMap.get(TENANT_ID.getName());
-            if (tenantId != null) {
+            if (tenantId != null && !tenantId.isEmpty() {
                 serializer.writeRaw(',');
                 serializer.writeStringField(TENANT_ID_ATTR_NAME, tenantId);
             }

--- a/powertools-logging/powertools-logging-logback/src/main/java/software/amazon/lambda/powertools/logging/logback/LambdaEcsEncoder.java
+++ b/powertools-logging/powertools-logging-logback/src/main/java/software/amazon/lambda/powertools/logging/logback/LambdaEcsEncoder.java
@@ -173,7 +173,7 @@ public class LambdaEcsEncoder extends EncoderBase<ILoggingEvent> {
             }
             
             String tenantId = mdcPropertyMap.get(TENANT_ID.getName());
-            if (tenantId != null && !tenantId.isEmpty() {
+            if (tenantId != null && !tenantId.isEmpty()) {
                 serializer.writeRaw(',');
                 serializer.writeStringField(TENANT_ID_ATTR_NAME, tenantId);
             }

--- a/powertools-logging/powertools-logging-logback/src/main/java/software/amazon/lambda/powertools/logging/logback/LambdaEcsEncoder.java
+++ b/powertools-logging/powertools-logging-logback/src/main/java/software/amazon/lambda/powertools/logging/logback/LambdaEcsEncoder.java
@@ -24,6 +24,7 @@ import static software.amazon.lambda.powertools.logging.internal.PowertoolsLogge
 import static software.amazon.lambda.powertools.logging.internal.PowertoolsLoggedFields.FUNCTION_TRACE_ID;
 import static software.amazon.lambda.powertools.logging.internal.PowertoolsLoggedFields.FUNCTION_VERSION;
 import static software.amazon.lambda.powertools.logging.logback.JsonUtils.*;
+import static software.amazon.lambda.powertools.logging.internal.PowertoolsLoggedFields.TENANT_ID;
 
 import ch.qos.logback.classic.pattern.ThrowableHandlingConverter;
 import ch.qos.logback.classic.pattern.ThrowableProxyConverter;
@@ -72,6 +73,7 @@ public class LambdaEcsEncoder extends EncoderBase<ILoggingEvent> {
     protected static final String FUNCTION_MEMORY_ATTR_NAME = "faas.memory";
     protected static final String FUNCTION_TRACE_ID_ATTR_NAME = "trace.id";
     protected static final String CORRELATION_ID_ATTR_NAME = "correlation.id";
+    protected static final String TENANT_ID_ATTR_NAME = "tenant.id";
 
     protected static final String ECS_VERSION = "1.2.0";
     protected static final String CLOUD_PROVIDER = "aws";
@@ -168,6 +170,12 @@ public class LambdaEcsEncoder extends EncoderBase<ILoggingEvent> {
             if (correlationId != null) {
                 serializer.writeRaw(',');
                 serializer.writeStringField(CORRELATION_ID_ATTR_NAME, correlationId);
+            }
+            
+            String tenantId = mdcPropertyMap.get(TENANT_ID.getName());
+            if (tenantId != null) {
+                serializer.writeRaw(',');
+                serializer.writeStringField(TENANT_ID_ATTR_NAME, tenantId);
             }
         }
     }

--- a/powertools-logging/powertools-logging-logback/src/main/java/software/amazon/lambda/powertools/logging/logback/LambdaJsonEncoder.java
+++ b/powertools-logging/powertools-logging-logback/src/main/java/software/amazon/lambda/powertools/logging/logback/LambdaJsonEncoder.java
@@ -124,7 +124,9 @@ public class LambdaJsonEncoder extends EncoderBase<ILoggingEvent> {
         if (includePowertoolsInfo) {
             for (Map.Entry<String, String> entry : sortedMap.entrySet()) {
                 if (PowertoolsLoggedFields.stringValues().contains(entry.getKey())
-                    && !(entry.getKey().equals(PowertoolsLoggedFields.SAMPLING_RATE.getName()) && entry.getValue().equals("0.0"))) {
+                    && !(entry.getKey().equals(PowertoolsLoggedFields.SAMPLING_RATE.getName()) && "0.0".equals(entry.getValue()))
+                    && !(entry.getKey().equals(PowertoolsLoggedFields.TENANT_ID.getName())
+                    && (entry.getValue() == null || entry.getValue().isEmpty()))) {
                     serializeMDCEntry(entry, serializer);
                 }
             }

--- a/powertools-logging/powertools-logging-logback/src/main/java/software/amazon/lambda/powertools/logging/logback/LambdaJsonEncoder.java
+++ b/powertools-logging/powertools-logging-logback/src/main/java/software/amazon/lambda/powertools/logging/logback/LambdaJsonEncoder.java
@@ -236,6 +236,7 @@ public class LambdaJsonEncoder extends EncoderBase<ILoggingEvent> {
      *     <li>xray_trace_id</li>
      *     <li>sampling_rate</li>
      *     <li>service</li>
+     *     <li>tenant_id</li> 
      * </ul>
      * <br/>
      * We strongly recommend to keep these information.

--- a/powertools-logging/powertools-logging-logback/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaEcsEncoderTest.java
+++ b/powertools-logging/powertools-logging-logback/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaEcsEncoderTest.java
@@ -88,7 +88,7 @@ class LambdaEcsEncoderTest {
 
         File logFile = new File("target/ecslogfile.json");
         assertThat(contentOf(logFile)).contains(
-                "\"ecs.version\":\"1.2.0\",\"log.level\":\"DEBUG\",\"message\":\"Test debug event\",\"service.name\":\"testLogback\",\"service.version\":\"1\",\"log.logger\":\"software.amazon.lambda.powertools.logging.internal.handler.PowertoolsLogEnabled\",\"process.thread.name\":\"main\",\"cloud.provider\":\"aws\",\"cloud.service.name\":\"lambda\",\"cloud.region\":\"us-east-1\",\"cloud.account.id\":\"123456789012\",\"faas.id\":\"arn:aws:lambda:us-east-1:123456789012:function:test\",\"faas.name\":\"test-function\",\"faas.version\":\"1\",\"faas.memory\":\"128\",\"faas.execution\":\"test-request-id\",\"faas.coldstart\":\"true\",\"trace.id\":\"1-63441c4a-abcdef012345678912345678\",\"myKey\":\"myValue\"}\n");
+            "\"ecs.version\":\"1.2.0\",\"log.level\":\"DEBUG\",\"message\":\"Test debug event\",\"service.name\":\"testLogback\",\"service.version\":\"1\",\"log.logger\":\"software.amazon.lambda.powertools.logging.internal.handler.PowertoolsLogEnabled\",\"process.thread.name\":\"main\",\"cloud.provider\":\"aws\",\"cloud.service.name\":\"lambda\",\"cloud.region\":\"us-east-1\",\"cloud.account.id\":\"123456789012\",\"faas.id\":\"arn:aws:lambda:us-east-1:123456789012:function:test\",\"faas.name\":\"test-function\",\"faas.version\":\"1\",\"faas.memory\":\"128\",\"faas.execution\":\"test-request-id\",\"faas.coldstart\":\"true\",\"trace.id\":\"1-63441c4a-abcdef012345678912345678\",\"tenant.id\":\"test-tenant\",\"myKey\":\"myValue\"}\n");
     }
 
     private final LoggingEvent loggingEvent = new LoggingEvent("fqcn", logger, Level.INFO, "message", null, null);
@@ -165,8 +165,11 @@ class LambdaEcsEncoderTest {
         result = new String(encoded, StandardCharsets.UTF_8);
 
         // THEN (stack is logged with root cause first)
-        assertThat(result).contains(
-                "\"message\":\"Error\",\"error.message\":\"Unexpected value\",\"error.type\":\"java.lang.IllegalStateException\",\"error.stack_trace\":\"java.lang.IllegalStateException: Unexpected value\\n");
+        assertThat(result)
+            .contains("\"message\":\"Error\",\"error.message\":\"Unexpected value\",\"error.type\":\"java.lang.IllegalStateException\"")
+            .containsAnyOf(
+                "\"error.stack_trace\":\"java.lang.IllegalStateException: Unexpected value\\n",
+                "\"error.stack_trace\":\"java.lang.IllegalStateException: Unexpected value\\r\\n");
     }
 
     private void setMDC() {

--- a/powertools-logging/powertools-logging-logback/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaJsonEncoderTest.java
+++ b/powertools-logging/powertools-logging-logback/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaJsonEncoderTest.java
@@ -196,6 +196,7 @@ class LambdaJsonEncoderTest {
         MDC.put(PowertoolsLoggedFields.FUNCTION_COLD_START.getName(), "false");
         MDC.put(PowertoolsLoggedFields.SAMPLING_RATE.getName(), "0.2");
         MDC.put(PowertoolsLoggedFields.SERVICE.getName(), "Service");
+        MDC.put(PowertoolsLoggedFields.TENANT_ID.getName(), "test-tenant");
 
         // WHEN
         byte[] encoded = encoder.encode(loggingEvent);
@@ -203,7 +204,6 @@ class LambdaJsonEncoderTest {
 
         // THEN
         assertThat(result).contains(
-                assertThat(result).contains(
                 "{\"level\":\"INFO\",\"message\":\"message\",\"cold_start\":false,\"function_arn\":\"arn:aws:lambda:us-east-1:123456789012:function:test\",\"function_memory_size\":128,\"function_name\":\"test-function\",\"function_request_id\":\"test-request-id\",\"function_version\":1,\"sampling_rate\":0.2,\"service\":\"Service\",\"tenant_id\":\"test-tenant\",\"timestamp\":\""
                 );
 
@@ -214,7 +214,7 @@ class LambdaJsonEncoderTest {
 
         // THEN (no powertools info in logs)
         assertThat(result).doesNotContain("cold_start", "function_arn", "function_memory_size", "function_name",
-                "function_request_id", "function_version", "sampling_rate", "service");
+            "function_request_id", "function_version", "sampling_rate", "service", "tenant_id");
     }
 
     @Test
@@ -443,7 +443,9 @@ class LambdaJsonEncoderTest {
         // THEN (stack is logged with root cause first)
         assertThat(result).contains("\"message\":\"Unexpected value\"")
                 .contains("\"name\":\"java.lang.IllegalStateException\"")
-                .contains("\"stack\":\"java.lang.IllegalStateException: Unexpected value\\n");
+            .containsAnyOf(
+                "\"stack\":\"java.lang.IllegalStateException: Unexpected value\\n",
+                "\"stack\":\"java.lang.IllegalStateException: Unexpected value\\r\\n");
     }
 
     @Test

--- a/powertools-logging/powertools-logging-logback/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaJsonEncoderTest.java
+++ b/powertools-logging/powertools-logging-logback/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaJsonEncoderTest.java
@@ -111,8 +111,8 @@ class LambdaJsonEncoderTest {
         // THEN
         File logFile = new File("target/logfile.json");
         assertThat(contentOf(logFile)).contains(
-                "{\"level\":\"DEBUG\",\"message\":\"Test debug event\",\"cold_start\":true,\"function_arn\":\"arn:aws:lambda:us-east-1:123456789012:function:test\",\"function_memory_size\":128,\"function_name\":\"test-function\",\"function_request_id\":\"test-request-id\",\"function_version\":1,\"service\":\"testLogback\",\"xray_trace_id\":\"1-63441c4a-abcdef012345678912345678\",\"myKey\":\"myValue\",\"timestamp\":");
-    }
+        "{\"level\":\"DEBUG\",\"message\":\"Test debug event\",\"cold_start\":true,\"function_arn\":\"arn:aws:lambda:us-east-1:123456789012:function:test\",\"function_memory_size\":128,\"function_name\":\"test-function\",\"function_request_id\":\"test-request-id\",\"function_version\":1,\"service\":\"testLogback\",\"tenant_id\":\"test-tenant\",\"xray_trace_id\":\"1-63441c4a-abcdef012345678912345678\",\"myKey\":\"myValue\",\"timestamp\":\"");
+        }
 
     @Test
     void shouldLogArgumentsAsJsonWhenUsingRawJson() {
@@ -203,7 +203,9 @@ class LambdaJsonEncoderTest {
 
         // THEN
         assertThat(result).contains(
-                "{\"level\":\"INFO\",\"message\":\"message\",\"cold_start\":false,\"function_arn\":\"arn:aws:lambda:us-east-1:123456789012:function:test\",\"function_memory_size\":128,\"function_name\":\"test-function\",\"function_request_id\":\"test-request-id\",\"function_version\":1,\"sampling_rate\":0.2,\"service\":\"Service\",\"timestamp\":");
+                assertThat(result).contains(
+                "{\"level\":\"INFO\",\"message\":\"message\",\"cold_start\":false,\"function_arn\":\"arn:aws:lambda:us-east-1:123456789012:function:test\",\"function_memory_size\":128,\"function_name\":\"test-function\",\"function_request_id\":\"test-request-id\",\"function_version\":1,\"sampling_rate\":0.2,\"service\":\"Service\",\"tenant_id\":\"test-tenant\",\"timestamp\":\""
+                );
 
         // WHEN (powertoolsInfo = false)
         encoder.setIncludePowertoolsInfo(false);

--- a/powertools-logging/powertools-logging-logback/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaJsonEncoderTest.java
+++ b/powertools-logging/powertools-logging-logback/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaJsonEncoderTest.java
@@ -483,4 +483,33 @@ class LambdaJsonEncoderTest {
         ;
     }
 
+    @Test
+    void shouldNotLogTenantIdWhenNull() {
+        // GIVEN
+        LambdaJsonEncoder encoder = new LambdaJsonEncoder();
+        MDC.put(PowertoolsLoggedFields.TENANT_ID.getName(), null);
+
+        // WHEN
+        byte[] encoded = encoder.encode(loggingEvent);
+        String result = new String(encoded, StandardCharsets.UTF_8);
+
+        // THEN
+        assertThat(result).doesNotContain("tenant_id");
+    }
+
+    @Test
+    void shouldNotLogTenantIdWhenEmpty() {
+        // GIVEN
+        LambdaJsonEncoder encoder = new LambdaJsonEncoder();
+        MDC.put(PowertoolsLoggedFields.TENANT_ID.getName(), "");
+
+        // WHEN
+        byte[] encoded = encoder.encode(loggingEvent);
+        String result = new String(encoded, StandardCharsets.UTF_8);
+
+        // THEN
+        assertThat(result).doesNotContain("tenant_id");
+    }
+
+
 }

--- a/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/internal/PowertoolsLoggedFields.java
+++ b/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/internal/PowertoolsLoggedFields.java
@@ -35,7 +35,8 @@ public enum PowertoolsLoggedFields {
     FUNCTION_TRACE_ID("xray_trace_id"),
     SAMPLING_RATE("sampling_rate"),
     CORRELATION_ID("correlation_id"),
-    SERVICE("service");
+    SERVICE("service"),
+    TENANT_ID("tenant_id");
 
     private final String name;
 
@@ -55,6 +56,10 @@ public enum PowertoolsLoggedFields {
         hashMap.put(FUNCTION_ARN.name, context.getInvokedFunctionArn());
         hashMap.put(FUNCTION_MEMORY_SIZE.name, String.valueOf(context.getMemoryLimitInMB()));
         hashMap.put(FUNCTION_REQUEST_ID.name, String.valueOf(context.getAwsRequestId()));
+        String tenantId = context.getTenantId();
+        if (tenantId != null && !tenantId.isEmpty()) {
+            hashMap.put(TENANT_ID.name, tenantId);
+        }
 
         return hashMap;
     }

--- a/powertools-logging/src/test/java/software/amazon/lambda/powertools/logging/internal/KeyBufferTest.java
+++ b/powertools-logging/src/test/java/software/amazon/lambda/powertools/logging/internal/KeyBufferTest.java
@@ -351,9 +351,9 @@ class KeyBufferTest {
             defaultBuffer.removeAll("key1");
 
             // Assert System.err received the warning
-            assertThat(errCapture)
-                    .hasToString(
-                            "WARN [KeyBuffer] - Some logs are not displayed because they were evicted from the buffer. Increase buffer size to store more logs in the buffer.\n");
+                assertThat(errCapture.toString())
+                    .contains(
+                        "WARN [KeyBuffer] - Some logs are not displayed because they were evicted from the buffer. Increase buffer size to store more logs in the buffer.");
         } finally {
             System.setErr(originalErr);
         }

--- a/powertools-logging/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspectTest.java
+++ b/powertools-logging/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspectTest.java
@@ -26,6 +26,7 @@ import static software.amazon.lambda.powertools.logging.internal.PowertoolsLogge
 import static software.amazon.lambda.powertools.logging.internal.PowertoolsLoggedFields.FUNCTION_TRACE_ID;
 import static software.amazon.lambda.powertools.logging.internal.PowertoolsLoggedFields.FUNCTION_VERSION;
 import static software.amazon.lambda.powertools.logging.internal.PowertoolsLoggedFields.SERVICE;
+import static software.amazon.lambda.powertools.logging.internal.PowertoolsLoggedFields.TENANT_ID;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -88,7 +89,7 @@ import software.amazon.lambda.powertools.logging.handlers.PowertoolsLogSamplingE
 
 class LambdaLoggingAspectTest {
 
-    private static final int EXPECTED_CONTEXT_SIZE = 8;
+    private static final int EXPECTED_CONTEXT_SIZE = 9;
     private RequestStreamHandler requestStreamHandler;
     private RequestHandler<Object, Object> requestHandler;
 
@@ -148,6 +149,7 @@ class LambdaLoggingAspectTest {
                 .containsEntry(FUNCTION_VERSION.getName(), "1")
                 .containsEntry(FUNCTION_NAME.getName(), "test-function")
                 .containsEntry(FUNCTION_REQUEST_ID.getName(), "test-request-id")
+                .containsEntry(TENANT_ID.getName(), "test-tenant")
                 .containsKey(FUNCTION_COLD_START.getName())
                 .containsKey(SERVICE.getName());
     }
@@ -166,6 +168,7 @@ class LambdaLoggingAspectTest {
                 .containsEntry(FUNCTION_VERSION.getName(), "1")
                 .containsEntry(FUNCTION_NAME.getName(), "test-function")
                 .containsEntry(FUNCTION_REQUEST_ID.getName(), "test-request-id")
+                .containsEntry(TENANT_ID.getName(), "test-tenant")
                 .containsKey(FUNCTION_COLD_START.getName())
                 .containsKey(SERVICE.getName());
     }


### PR DESCRIPTION
## Description

Implements automatic `tenant_id` logging for AWS Lambda Tenant Isolation feature with null-safe serialization in Logback JSON encoder. Ensures `tenant_id` is only logged when it contains a valid value.

## Changes

✅ Add null-safety check to `LambdaJsonEncoder.serializePowertools()`
✅ Add `TENANT_ID_RESOLVER` in Log4j2 `PowertoolsResolver`
✅ Add `TENANT_ID` enum to `PowertoolsLoggedFields`
✅ Update `LambdaJsonLayout.json` and `LambdaEcsLayout.json`
✅ Add `tenant_id` serialization to `LambdaEcsEncoder`
✅ Add unit tests for null and empty `tenant_id` scenarios
✅ Fix test assertion and OS compatibility issues

## Implementation Details

- Skip `tenant_id` serialization when null or empty
- Follows pattern used for `sampling_rate`
- Supports both Log4j2 and Logback backends
- No user code changes required

## Testing

Tests run: 18, Failures: 0, Errors: 0, BUILD SUCCESS

Test coverage:
- Valid `tenant_id` is logged
- Null `tenant_id` is NOT logged
- Empty `tenant_id` is NOT logged
- Respects `includePowertoolsInfo` flag

## Related Issues

Closes #2348

## By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

- [x] I confirm that I can use, modify, copy, and redistribute this contribution under the terms of your choice

## Acknowledgment

- [x] This feature request meets [Powertools for AWS Lambda (Java) Tenets](https://docs.powertools.aws.dev/lambda/java/latest/#tenets)
- [x] I have read the [CONTRIBUTING](https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md) guidelines
- [x] Tests pass locally
- [x] No breaking changes