### PR TITLE
fix(deps): bump Jackson to 2.22.0 to address CVE-2026-54513

### DIFF
--- a/examples/powertools-examples-core-utilities/gradle/build.gradle
+++ b/examples/powertools-examples-core-utilities/gradle/build.gradle
@@ -24,10 +24,10 @@ repositories {
 
 dependencies {
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.2'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.22.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.22.0'
     implementation 'com.amazonaws:aws-lambda-java-events:3.16.0'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.22.0'
     implementation 'org.aspectj:aspectjrt:1.9.20.1'
     aspect 'software.amazon.lambda:powertools-tracing:2.10.0'
     aspect 'software.amazon.lambda:powertools-logging-log4j:2.10.0'

--- a/examples/powertools-examples-kafka/tools/pom.xml
+++ b/examples/powertools-examples-kafka/tools/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.19.0</version>
+            <version>2.22.0</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <maven.deploy.plugin.version>3.1.2</maven.deploy.plugin.version>
         <log4j.version>2.26.0</log4j.version>
         <slf4j.version>2.0.17</slf4j.version>
-        <jackson.version>2.21.2</jackson.version>
+        <jackson.version>2.22.0</jackson.version>
         <aws.sdk.version>2.46.14</aws.sdk.version>
         <aws.xray.recorder.version>2.21.0</aws.xray.recorder.version>
         <payloadoffloading-common.version>2.2.0</payloadoffloading-common.version>


### PR DESCRIPTION
## Summary

### Changes

Bumps Jackson to 2.22.0 across the project to fix CVE-2026-54513, an
array subtype allowlist bypass in `BasicPolymorphicTypeValidator`. The
root `jackson.version` was 2.21.2, which falls in the affected range
(>= 2.19.0, < 2.21.4). 2.22.0 is the newest 2.x release and targets Java
8 bytecode, so it stays compatible with our Java 11 baseline.

Updated three locations:
- `pom.xml`: `jackson.version` 2.21.2 to 2.22.0 (drives the Jackson BOM
  that all modules inherit)
- `examples/powertools-examples-kafka/tools/pom.xml`: pinned
  jackson-databind 2.19.0 to 2.22.0
- `examples/powertools-examples-core-utilities/gradle/build.gradle`:
  jackson-annotations, jackson-databind, and jackson-datatype-jsr310
  2.13.2 to 2.22.0

**Issue number:** #2544

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
