### PR TITLE
fix: bump jackson to address CVE-2026-54513 fixes #2544

### DIFF
--- a/examples/powertools-examples-core-utilities/gradle/build.gradle
+++ b/examples/powertools-examples-core-utilities/gradle/build.gradle
@@ -24,10 +24,10 @@ repositories {
 
 dependencies {
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.2'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.2'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.22.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.22.1'
     implementation 'com.amazonaws:aws-lambda-java-events:3.16.0'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.22.1'
     implementation 'org.aspectj:aspectjrt:1.9.20.1'
     aspect 'software.amazon.lambda:powertools-tracing:2.10.0'
     aspect 'software.amazon.lambda:powertools-logging-log4j:2.10.0'

--- a/examples/powertools-examples-kafka/tools/pom.xml
+++ b/examples/powertools-examples-kafka/tools/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.19.0</version>
+            <version>2.22.1</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <maven.deploy.plugin.version>3.1.2</maven.deploy.plugin.version>
         <log4j.version>2.26.0</log4j.version>
         <slf4j.version>2.0.17</slf4j.version>
-        <jackson.version>2.21.2</jackson.version>
+        <jackson.version>2.22.1</jackson.version>
         <aws.sdk.version>2.47.3</aws.sdk.version>
         <aws.xray.recorder.version>2.21.0</aws.xray.recorder.version>
         <payloadoffloading-common.version>2.2.0</payloadoffloading-common.version>


### PR DESCRIPTION
## Summary

### Changes

Bump Jackson to 2.22.1 to address CVE-2026-54513 closes #2544 

**Issue number:** #2544

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
