### PR TITLE
chore(v2): drop java 11 support

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -72,7 +72,6 @@ jobs:
     strategy:
       matrix:
         java:
-          - 11
           - 17
           - 21
           - 25

--- a/.github/workflows/check-e2e.yml
+++ b/.github/workflows/check-e2e.yml
@@ -99,7 +99,6 @@ jobs:
       max-parallel: 20
       matrix:
         java:
-          - 11
           - 17
           - 21
           - 25

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build-docs-website:
 
 docs-local-docker:
 	docker build -t squidfunk/mkdocs-material ./docs/
-	docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material
+	docker run --rm -it -p 8000:8000 -v $(CURDIR):/docs squidfunk/mkdocs-material
 
 test:
 	mvn test

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build-docs-website:
 
 docs-local-docker:
 	docker build -t squidfunk/mkdocs-material ./docs/
-	docker run --rm -it -p 8000:8000 -v $(CURDIR):/docs squidfunk/mkdocs-material
+	docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material
 
 test:
 	mvn test

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Next, configure the aspectj-maven-plugin to compile-time weave (CTW) the aws-lam
              <artifactId>aspectj-maven-plugin</artifactId>
              <version>1.14</version>
              <configuration>
-                 <source>11</source>
-                 <target>11</target>
-                 <complianceLevel>11</complianceLevel>
+                 <source>17</source>
+                 <target>17</target>
+                 <complianceLevel>17</complianceLevel>
                  <aspectLibraries>
                      <aspectLibrary>
                          <groupId>software.amazon.lambda</groupId>
@@ -120,14 +120,14 @@ Next, configure the aspectj-maven-plugin to compile-time weave (CTW) the aws-lam
             implementation "org.aspectj:aspectjrt:1.9.22"
         }
         
-        sourceCompatibility = 11
-        targetCompatibility = 11
+        sourceCompatibility = 17
+        targetCompatibility = 17
 ```
 </details>
 
 
 ### Java Compatibility
-Powertools for AWS Lambda (Java) supports all Java versions from 11 to 25 in line with the [corresponding Lambda runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
+Powertools for AWS Lambda (Java) supports all Java versions from 17 to 25 in line with the [corresponding Lambda runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
 
 For the modules that provide annotations, Powertools for AWS Lambda (Java) leverages the **aspectj** library.
 You may need to add the appropriate version of `aspectjrt` to your dependencies based on the JDK used for building your function:
@@ -146,10 +146,10 @@ You may need to add the appropriate version of `aspectjrt` to your dependencies 
 Use the following [dependency matrix](https://github.com/eclipse-aspectj/aspectj/blob/master/docs/release/JavaVersionCompatibility.adoc) to understand which AspectJ version to use based on your JDK version:
 
 | JDK version | aspectj version        |
-|-------------|------------------------|
-| `11-17`     | `1.9.20.1` (or higher) |
-| `21`        | `1.9.21` (or higher)   |
-| `25`        | `1.9.25` (or higher)   |
+|-----------|------------------------|
+| `17`     | `1.9.20.1` (or higher) |
+| `21`      | `1.9.21` (or higher)   |
+| `25`      | `1.9.25` (or higher)   |
 
 </details>
 

--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -54,9 +54,9 @@ Depending on preference, you must choose to use either _log4j2_ or _logback_ as 
                  <artifactId>aspectj-maven-plugin</artifactId>
                  <version>1.14</version>
                  <configuration>
-                     <source>11</source> <!-- or higher -->
-                     <target>11</target> <!-- or higher -->
-                     <complianceLevel>11</complianceLevel> <!-- or higher -->
+                     <source>17</source> <!-- or higher -->
+                     <target>17</target> <!-- or higher -->
+                     <complianceLevel>17</complianceLevel> <!-- or higher -->
                      <aspectLibraries>
                          <aspectLibrary>
                              <groupId>software.amazon.lambda</groupId>
@@ -113,9 +113,9 @@ Depending on preference, you must choose to use either _log4j2_ or _logback_ as 
                  <artifactId>aspectj-maven-plugin</artifactId>
                  <version>1.14</version>
                  <configuration>
-                     <source>11</source> <!-- or higher -->
-                     <target>11</target> <!-- or higher -->
-                     <complianceLevel>11</complianceLevel> <!-- or higher -->
+                     <source>17</source> <!-- or higher -->
+                     <target>17</target> <!-- or higher -->
+                     <complianceLevel>17</complianceLevel> <!-- or higher -->
                      <aspectLibraries>
                          <aspectLibrary>
                              <groupId>software.amazon.lambda</groupId>
@@ -163,8 +163,8 @@ Depending on preference, you must choose to use either _log4j2_ or _logback_ as 
             implementation 'software.amazon.lambda:powertools-logging-log4j:{{ powertools.version }}'
         }
         
-        sourceCompatibility = 11
-        targetCompatibility = 11
+        sourceCompatibility = 17
+        targetCompatibility = 17
     ```
 
 === "logback"
@@ -184,8 +184,8 @@ Depending on preference, you must choose to use either _log4j2_ or _logback_ as 
             implementation 'software.amazon.lambda:powertools-logging-logback:{{ powertools.version }}'
         }
         
-        sourceCompatibility = 11
-        targetCompatibility = 11
+        sourceCompatibility = 17
+        targetCompatibility = 17
     ```
 
 

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -57,9 +57,9 @@ Visit the AWS documentation for a complete explanation for [Amazon CloudWatch co
                  <artifactId>aspectj-maven-plugin</artifactId>
                  <version>1.14</version>
                  <configuration>
-                     <source>11</source> <!-- or higher -->
-                     <target>11</target> <!-- or higher -->
-                     <complianceLevel>11</complianceLevel> <!-- or higher -->
+                     <source>17</source> <!-- or higher -->
+                     <target>17</target> <!-- or higher -->
+                     <complianceLevel>17</complianceLevel> <!-- or higher -->
                      <aspectLibraries>
                          <aspectLibrary>
                              <groupId>software.amazon.lambda</groupId>
@@ -105,8 +105,8 @@ Visit the AWS documentation for a complete explanation for [Amazon CloudWatch co
             implementation 'software.amazon.lambda:powertools-metrics:{{ powertools.version }}' // Use this instead of 'aspect' when using the functional approach
         }
 
-        sourceCompatibility = 11
-        targetCompatibility = 11
+        sourceCompatibility = 17
+        targetCompatibility = 17
     ```
 
 ## Getting started
@@ -181,7 +181,7 @@ For most use-cases, we recommend using Environment variables and only overwrite 
             Type: AWS::Serverless::Function
             Properties:
             ...
-            Runtime: java11
+            Runtime: java17
             Environment:
                 Variables:
                     POWERTOOLS_SERVICE_NAME: payment

--- a/docs/core/tracing.md
+++ b/docs/core/tracing.md
@@ -41,9 +41,9 @@ a provides functionality to reduce the overhead of performing common tracing tas
                  <artifactId>aspectj-maven-plugin</artifactId>
                  <version>1.14</version>
                  <configuration>
-                     <source>11</source> <!-- or higher -->
-                     <target>11</target> <!-- or higher -->
-                     <complianceLevel>11</complianceLevel> <!-- or higher -->
+                     <source>17</source> <!-- or higher -->
+                     <target>17</target> <!-- or higher -->
+                     <complianceLevel>17</complianceLevel> <!-- or higher -->
                      <aspectLibraries>
                          <aspectLibrary>
                              <groupId>software.amazon.lambda</groupId>
@@ -89,8 +89,8 @@ a provides functionality to reduce the overhead of performing common tracing tas
             implementation 'software.amazon.lambda:powertools-tracing:{{ powertools.version }}' // Use this instead of 'aspect' when using the functional approach
         }
         
-        sourceCompatibility = 11 // or higher
-        targetCompatibility = 11 // or higher
+        sourceCompatibility = 17 // or higher
+        targetCompatibility = 17 // or higher
     ```
 
 ## Initialization
@@ -107,7 +107,7 @@ Before your use this utility, your AWS Lambda function [must have permissions](h
             Type: AWS::Serverless::Function
             Properties:
             ...
-            Runtime: java11
+            Runtime: java17
     
             Tracing: Active
             Environment:
@@ -217,7 +217,7 @@ specifying a different `captureMode` to always record response, exception, both,
             Type: AWS::Serverless::Function
             Properties:
             ...
-            Runtime: java11
+            Runtime: java17
     
             Tracing: Active
             Environment:

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,9 +118,9 @@ Powertools for AWS Lambda (Java) dependencies are available in Maven Central. Yo
                  <artifactId>aspectj-maven-plugin</artifactId>
                  <version>1.14</version>
                  <configuration>
-                     <source>11</source> <!-- or higher -->
-                     <target>11</target> <!-- or higher -->
-                     <complianceLevel>11</complianceLevel> <!-- or higher -->
+                     <source>17</source> <!-- or higher -->
+                     <target>17</target> <!-- or higher -->
+                     <complianceLevel>17</complianceLevel> <!-- or higher -->
                      <aspectLibraries>
                          <aspectLibrary>
                              <groupId>software.amazon.lambda</groupId>
@@ -183,15 +183,15 @@ Powertools for AWS Lambda (Java) dependencies are available in Maven Central. Yo
             aspect 'software.amazon.lambda:powertools-metrics:{{ powertools.version }}'
         }
         
-        sourceCompatibility = 11
-        targetCompatibility = 11
+        sourceCompatibility = 17
+        targetCompatibility = 17
     ```
 
 ???+ tip "Don't want to use AspectJ?"
     Powertools for AWS Lambda (Java) now provides a functional API that doesn't require AspectJ configuration. Learn more about the [functional approach](./usage-patterns.md#functional-approach).
 
 ### Java Compatibility
-Powertools for AWS Lambda (Java) supports all Java versions from 11 to 25 in line with the [corresponding Lambda runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
+Powertools for AWS Lambda (Java) supports all Java versions from 17 to 25 in line with the [corresponding Lambda runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
 
 In addition to the functional approach, [Logging](./core/logging.md), [Metrics](./core/metrics.md), [Tracing](./core/tracing.md), [Parameters](./utilities/parameters.md), [Idempotency](./utilities/idempotency.md), [Validation](./utilities/validation.md), and [Large Messages](./utilities/large_messages.md) utilities support annotations using AspectJ, which require configuration of the `aspectjrt` runtime library.
 
@@ -208,10 +208,10 @@ You may need to add the appropriate version of `aspectjrt` to your dependencies 
 Use the following [dependency matrix](https://github.com/eclipse-aspectj/aspectj/blob/master/docs/release/JavaVersionCompatibility.adoc) to understand which AspectJ version to use based on your JDK version:
 
 | JDK version | aspectj version        |
-|-------------|------------------------|
-| `11-17`     | `1.9.20.1` (or higher) |
-| `21`        | `1.9.21` (or higher)   |
-| `25`        | `1.9.25` (or higher)   |
+|----------|------------------------|
+| `17`     | `1.9.20.1` (or higher) |
+| `21`     | `1.9.21` (or higher)   |
+| `25`     | `1.9.25` (or higher)   |
 
 ## Environment variables
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -22,29 +22,29 @@ We've made minimal breaking changes to make your transition to `v2` as smooth as
 
 The following table shows a summary of the changes made in `v2` and whether code changes are necessary. Each change that requires a code change links to a section below explaining more details.
 
-| Area                 | Change                                                                                                                                                                                   | Code change required |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
-| **Logging**          | The [logging module was re-designed](#redesigned-logging-utility) from scratch to support popular Java logging paradigms and libraries like `log4j2`, `logback`, and `slf4j`.            | Yes                  |
-| **Metrics**          | [Changed public interface](#updated-metrics-utility-interface) to remove direct coupling with `aws-embedded-metrics-java`.                                                               | Yes                  |
-| **Tracing**          | [Removed deprecated `captureResponse` and `captureError` options](#deprecated-capture-mode-related-tracing-annotation-parameters) on `@Tracing` annotation.                              | Yes                  |
-| **Idempotency**      | The [`powertools-idempotency` module was split by provider](#idempotency-utility-split-into-sub-modules-by-provider) to improve modularity and reduce the deployment package size.       | Yes                  |
-| **Idempotency**      | Updated `IdempotencyConfig` interface to support addition of response hooks.                                                                                                             | No                   |
-| **Parameters**       | The [`powertools-parameters` module was split by provider](#parameters-utility-split-into-sub-modules-by-provider) to improve modularity and reduce the deployment package size.         | Yes                  |
+| Area                 | Change                                                                                                                                                                                 | Code change required |
+| -------------------- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| -------------------- |
+| **Logging**          | The [logging module was re-designed](#redesigned-logging-utility) from scratch to support popular Java logging paradigms and libraries like `log4j2`, `logback`, and `slf4j`.          | Yes                  |
+| **Metrics**          | [Changed public interface](#updated-metrics-utility-interface) to remove direct coupling with `aws-embedded-metrics-java`.                                                             | Yes                  |
+| **Tracing**          | [Removed deprecated `captureResponse` and `captureError` options](#deprecated-capture-mode-related-tracing-annotation-parameters) on `@Tracing` annotation.                            | Yes                  |
+| **Idempotency**      | The [`powertools-idempotency` module was split by provider](#idempotency-utility-split-into-sub-modules-by-provider) to improve modularity and reduce the deployment package size.     | Yes                  |
+| **Idempotency**      | Updated `IdempotencyConfig` interface to support addition of response hooks.                                                                                                           | No                   |
+| **Parameters**       | The [`powertools-parameters` module was split by provider](#parameters-utility-split-into-sub-modules-by-provider) to improve modularity and reduce the deployment package size.       | Yes                  |
 | **Batch Processing** | [Removed deprecated `powertools-sqs` module](#removed-powertools-sqs-module-in-favor-of-powertools-batch) in favor of the more generic [Batch Processing](./utilities/batch.md) utility. | Yes                  |
-| **Batch Processing** | Updated Batch Processing `BatchMessageHandler` interface to add support for parallel processing.                                                                                         | No                   |
-| **Validation**       | The `@Validation` utility returns 4xx error codes instead of 5xx error codes when used with API Gateway now.                                                                             | No                   |
-| **Validation**       | Validating batch event sources now adds failed events as partial batch failures and does not fail the whole batch anymore.                                                               | No                   |
-| **Custom Resources** | [Removed deprecated `Response.failed()` and `Response.success()` methods](#custom-resources-updates-the-response-class).                                                                 | Yes                  |
-| **Custom Resources** | Changed interface of `Response` class to add an optional `reason` field.                                                                                                                 | No                   |
-| **Dependencies**     | Renamed `powertools-core` to `powertools-common`. This module should not be used as direct dependency and is listed here for completeness.                                               | No                   |
-| **Dependencies**     | [Removed `org.aspectj.aspectjrt` as project dependency](#aspectj-runtime-not-included-by-default-anymore) in favor of consumers including the version they prefer.                       | Yes                  |
-| **Language support** | Removed support for Java 8. The minimum required Java version is Java 11.                                                                                                                | N/A                  |
+| **Batch Processing** | Updated Batch Processing `BatchMessageHandler` interface to add support for parallel processing.                                                                                       | No                   |
+| **Validation**       | The `@Validation` utility returns 4xx error codes instead of 5xx error codes when used with API Gateway now.                                                                           | No                   |
+| **Validation**       | Validating batch event sources now adds failed events as partial batch failures and does not fail the whole batch anymore.                                                             | No                   |
+| **Custom Resources** | [Removed deprecated `Response.failed()` and `Response.success()` methods](#custom-resources-updates-the-response-class).                                                               | Yes                  |
+| **Custom Resources** | Changed interface of `Response` class to add an optional `reason` field.                                                                                                               | No                   |
+| **Dependencies**     | Renamed `powertools-core` to `powertools-common`. This module should not be used as direct dependency and is listed here for completeness.                                             | No                   |
+| **Dependencies**     | [Removed `org.aspectj.aspectjrt` as project dependency](#aspectj-runtime-not-included-by-default-anymore) in favor of consumers including the version they prefer.                     | Yes                  |
+| **Language support** | Removed support for Java 11. The minimum required Java version is Java 17.                                                                                                             | N/A                  |
 
 ### First Steps
 
 Before you start, we suggest making a copy of your current working project or create a new branch with `git`.
 
-1. **Upgrade** Java to at least version 11. While version 11 is supported, we recommend using the [newest available LTS version](https://downloads.corretto.aws/#/downloads){target="\_blank"} of Java.
+1. **Upgrade** Java to at least version 17. While version 17 is supported, we recommend using the [newest available LTS version](https://downloads.corretto.aws/#/downloads){target="\_blank"} of Java.
 2. **Review** the following section to confirm if you need to make changes to your code.
 
 ## Redesigned Logging Utility

--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -50,9 +50,9 @@ times with the same parameters**. This makes idempotent operations safe to retry
                  <artifactId>aspectj-maven-plugin</artifactId>
                  <version>1.14</version>
                  <configuration>
-                     <source>11</source> <!-- or higher -->
-                     <target>11</target> <!-- or higher -->
-                     <complianceLevel>11</complianceLevel> <!-- or higher -->
+                     <source>17</source> <!-- or higher -->
+                     <target>17</target> <!-- or higher -->
+                     <complianceLevel>17</complianceLevel> <!-- or higher -->
                      <aspectLibraries>
                          <aspectLibrary>
                              <groupId>software.amazon.lambda</groupId>
@@ -98,8 +98,8 @@ times with the same parameters**. This makes idempotent operations safe to retry
             implementation 'software.amazon.lambda:powertools-idempotency-dynamodb:{{ powertools.version }}'
         }
         
-        sourceCompatibility = 11 // or higher
-        targetCompatibility = 11 // or higher
+        sourceCompatibility = 17 // or higher
+        targetCompatibility = 17 // or higher
     ```
 
 ### Required resources
@@ -1256,7 +1256,7 @@ To unit test your function with DynamoDB Local, you can refer to this guide to [
         <dependency>
            <groupId>com.amazonaws</groupId>
            <artifactId>DynamoDBLocal</artifactId>
-           <!-- Use newest version if you are on Java >11 -->
+           <!-- Use newest version if you are on Java >17 -->
            <!-- https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocalHistory.html -->
            <version>2.2.0</version>
             <scope>test</scope>

--- a/docs/utilities/lambda_metadata.md
+++ b/docs/utilities/lambda_metadata.md
@@ -43,8 +43,8 @@ Lambda Metadata provides idiomatic access to the Lambda Metadata Endpoint (LMDS)
             implementation 'software.amazon.lambda:powertools-lambda-metadata:{{ powertools.version }}'
         }
 
-        sourceCompatibility = 11
-        targetCompatibility = 11
+        sourceCompatibility = 17
+        targetCompatibility = 17
     ```
 
 ### IAM Permissions

--- a/docs/utilities/large_messages.md
+++ b/docs/utilities/large_messages.md
@@ -115,9 +115,9 @@ of [amazon-sqs-java-extended-client-lib](https://github.com/awslabs/amazon-sqs-j
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <version>1.14</version>
                 <configuration>
-                    <source>11</source> <!-- or higher -->
-                    <target>11</target> <!-- or higher -->
-                    <complianceLevel>11</complianceLevel> <!-- or higher -->
+                    <source>17</source> <!-- or higher -->
+                    <target>17</target> <!-- or higher -->
+                    <complianceLevel>17</complianceLevel> <!-- or higher -->
                     <aspectLibraries>
                         <aspectLibrary>
                             <groupId>software.amazon.lambda</groupId>
@@ -162,8 +162,8 @@ of [amazon-sqs-java-extended-client-lib](https://github.com/awslabs/amazon-sqs-j
             aspect 'software.amazon.lambda:powertools-large-messages:{{ powertools.version }}' // Use 'implementation' instead of 'aspect' when using the functional approach
         }
         
-        sourceCompatibility = 11 // or higher
-        targetCompatibility = 11 // or higher
+        sourceCompatibility = 17 // or higher
+        targetCompatibility = 17 // or higher
     ```
 
 ## Permissions

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -58,9 +58,9 @@ Note that you must provide the concrete parameters module you want to use below 
                  <artifactId>aspectj-maven-plugin</artifactId>
                  <version>1.14</version>
                  <configuration>
-                     <source>11</source> <!-- or higher -->
-                     <target>11</target> <!-- or higher -->
-                     <complianceLevel>11</complianceLevel> <!-- or higher -->
+                     <source>17</source> <!-- or higher -->
+                     <target>17</target> <!-- or higher -->
+                     <complianceLevel>17</complianceLevel> <!-- or higher -->
                      <aspectLibraries>
                          <!-- TODO! Provide an aspectLibrary for each of the parameters module(s) you want to use here -->
                          <aspectLibrary>
@@ -108,8 +108,8 @@ Note that you must provide the concrete parameters module you want to use below 
             implementation 'software.amazon.lambda:powertools-parameters-secrets:{{ powertools.version }}' // Use this instead of 'aspect' when using provider classes directly
         }
         
-        sourceCompatibility = 11 // or higher
-        targetCompatibility = 11 // or higher
+        sourceCompatibility = 17 // or higher
+        targetCompatibility = 17 // or higher
     ```
 
 **IAM Permissions**

--- a/docs/utilities/validation.md
+++ b/docs/utilities/validation.md
@@ -35,9 +35,9 @@ This utility provides JSON Schema validation for payloads held within events and
                  <artifactId>aspectj-maven-plugin</artifactId>
                  <version>1.14</version>
                  <configuration>
-                     <source>11</source> <!-- or higher -->
-                     <target>11</target> <!-- or higher -->
-                     <complianceLevel>11</complianceLevel> <!-- or higher -->
+                     <source>17</source> <!-- or higher -->
+                     <target>17</target> <!-- or higher -->
+                     <complianceLevel>17</complianceLevel> <!-- or higher -->
                      <aspectLibraries>
                          <aspectLibrary>
                              <groupId>software.amazon.lambda</groupId>
@@ -83,8 +83,8 @@ This utility provides JSON Schema validation for payloads held within events and
             implementation 'software.amazon.lambda:powertools-validation:{{ powertools.version }}' // Use this instead of 'aspect' when using the functional approach
         }
         
-        sourceCompatibility = 11 // or higher
-        targetCompatibility = 11 // or higher
+        sourceCompatibility = 17 // or higher
+        targetCompatibility = 17 // or higher
     ```
 
 ## Validating events

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,7 +34,7 @@ Many of the examples use [AWS Serverless Application Model](https://aws.amazon.c
 To use the SAM CLI, you need the following tools.
 
 * SAM CLI - [Install the SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
-* Java11 - [Install the Java 11](https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/downloads-list.html)
+* Java17 - [Install the Java 17](https://docs.aws.amazon.com/corretto/latest/corretto-17-ug/downloads-list.html)
 * Maven - [Install Maven](https://maven.apache.org/install.html)
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
@@ -67,7 +67,6 @@ If you're not using SAM, you can look for examples for other tools under [powert
 
 You can find more examples in the https://github.com/aws/aws-sam-cli-app-templates project:
 
-* [Java 11 + Maven](https://github.com/aws/aws-sam-cli-app-templates/tree/master/java11/hello-pt-maven)
 * [Java 17 + Maven](https://github.com/aws/aws-sam-cli-app-templates/tree/master/java17/hello-pt-maven)
 * [Java 17 + Gradle](https://github.com/aws/aws-sam-cli-app-templates/tree/master/java17/hello-pt-gradle)
 

--- a/examples/powertools-examples-batch/deploy/ddb-streams/template.yaml
+++ b/examples/powertools-examples-batch/deploy/ddb-streams/template.yaml
@@ -6,7 +6,7 @@ Description: >
 Globals:
   Function:
     Timeout: 20
-    Runtime: java11
+    Runtime: java17
     MemorySize: 512
     Tracing: Active
     Architectures:

--- a/examples/powertools-examples-batch/deploy/kinesis/template.yml
+++ b/examples/powertools-examples-batch/deploy/kinesis/template.yml
@@ -6,7 +6,7 @@ Description: >
 Globals:
   Function:
     Timeout: 20
-    Runtime: java11
+    Runtime: java17
     MemorySize: 512
     Tracing: Active
     Environment:

--- a/examples/powertools-examples-batch/deploy/sqs/template.yml
+++ b/examples/powertools-examples-batch/deploy/sqs/template.yml
@@ -6,7 +6,7 @@ Description: >
 Globals:
   Function:
     Timeout: 20
-    Runtime: java11
+    Runtime: java17
     MemorySize: 5400
     Environment:
       Variables:

--- a/examples/powertools-examples-batch/pom.xml
+++ b/examples/powertools-examples-batch/pom.xml
@@ -11,8 +11,8 @@
     <name>Powertools for AWS Lambda (Java) - Examples - Batch</name>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <aspectj.version>1.9.20.1</aspectj.version>
         <sdk.version>2.44.13</sdk.version>
     </properties>

--- a/examples/powertools-examples-cloudformation/README.md
+++ b/examples/powertools-examples-cloudformation/README.md
@@ -22,7 +22,7 @@ sam deploy --guided --parameter-overrides BucketNameParam=my-unique-bucket-2.10.
 To use CDK you need the following tools.
 
 * CDK - [Install CDK](https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html)
-* Java 11 - [Install Java 11](https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/downloads-list.html)
+* Java 17 - [Install Java 17](https://docs.aws.amazon.com/corretto/latest/corretto-17-ug/downloads-list.html)
 * Maven - [Install Maven](https://maven.apache.org/install.html)
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 

--- a/examples/powertools-examples-cloudformation/infra/cdk/pom.xml
+++ b/examples/powertools-examples-cloudformation/infra/cdk/pom.xml
@@ -20,8 +20,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
 

--- a/examples/powertools-examples-cloudformation/infra/sam/template.yaml
+++ b/examples/powertools-examples-cloudformation/infra/sam/template.yaml
@@ -25,7 +25,7 @@ Resources:
     Properties:
       CodeUri: ../../
       Handler: helloworld.App::handleRequest
-      Runtime: java11
+      Runtime: java17
       Architectures:
         - x86_64
       MemorySize: 512

--- a/examples/powertools-examples-cloudformation/pom.xml
+++ b/examples/powertools-examples-cloudformation/pom.xml
@@ -10,8 +10,8 @@
     <name>Powertools for AWS Lambda (Java) - Examples - CloudFormation</name>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <lambda.core.version>1.4.0</lambda.core.version>
         <lambda.events.version>3.16.1</lambda.events.version>
         <aws.sdk.version>2.48.0</aws.sdk.version>

--- a/examples/powertools-examples-core-utilities/cdk/app/pom.xml
+++ b/examples/powertools-examples-core-utilities/cdk/app/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <log4j.version>2.26.0</log4j.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <aspectj.version>1.9.20.1</aspectj.version>
     </properties>
 

--- a/examples/powertools-examples-core-utilities/cdk/infra/pom.xml
+++ b/examples/powertools-examples-core-utilities/cdk/infra/pom.xml
@@ -18,8 +18,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.15.0</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/examples/powertools-examples-core-utilities/cdk/infra/src/main/java/cdk/CdkStack.java
+++ b/examples/powertools-examples-core-utilities/cdk/infra/src/main/java/cdk/CdkStack.java
@@ -94,13 +94,13 @@ public class CdkStack extends Stack {
         environment.put("POWERTOOLS_METRICS_NAMESPACE", "Coreutilities");
 
         return Function.Builder.create(this, "HelloWorldFunction")
-                .runtime(Runtime.JAVA_11)
+                .runtime(Runtime.JAVA_17)
                 .memorySize(512)
                 .timeout(Duration.seconds(20))
                 .tracing(Tracing.ACTIVE)
                 .code(Code.fromAsset("../app/", AssetOptions.builder()
                         .bundling(BundlingOptions.builder()
-                                .image(Runtime.JAVA_11.getBundlingImage())
+                                .image(Runtime.JAVA_17.getBundlingImage())
                                 .command(functionPackageInstructions)
                                 .build())
                         .build()))
@@ -120,13 +120,13 @@ public class CdkStack extends Stack {
         environment.put("POWERTOOLS_SERVICE_NAME", "hello");
 
         return Function.Builder.create(this, "HelloWorldStreamFunction")
-                .runtime(Runtime.JAVA_11)
+                .runtime(Runtime.JAVA_17)
                 .memorySize(512)
                 .timeout(Duration.seconds(20))
                 .tracing(Tracing.ACTIVE)
                 .code(Code.fromAsset("../app/", AssetOptions.builder()
                         .bundling(BundlingOptions.builder()
-                                .image(Runtime.JAVA_11.getBundlingImage())
+                                .image(Runtime.JAVA_17.getBundlingImage())
                                 .command(functionPackageInstructions)
                                 .build())
                         .build()))

--- a/examples/powertools-examples-core-utilities/gradle/README.md
+++ b/examples/powertools-examples-core-utilities/gradle/README.md
@@ -1,7 +1,7 @@
 #  Powertools for AWS Lambda (Java) - Core Utilities Example with Gradle
 
 This project demonstrates the Lambda for Powertools Java module deployed using [Serverless Application Model](https://aws.amazon.com/serverless/sam/) with
-[Gradle](https://gradle.org/) running the build. This example is configured for Java 11 only; in order to use a newer version, check out the Gradle 
+[Gradle](https://gradle.org/) running the build. This example is configured for Java 17 only; in order to use a newer version, check out the Gradle 
 configuration guide [in the main project README](../../../README.md).
 
 You can also use `sam init` to create a new Gradle-powered Powertools application - choose to use the **AWS Quick Start Templates**,

--- a/examples/powertools-examples-core-utilities/gradle/build.gradle
+++ b/examples/powertools-examples-core-utilities/gradle/build.gradle
@@ -9,8 +9,8 @@ wrapper {
 }
 
 compileJava {
-    sourceCompatibility = "11"
-    targetCompatibility = "11"
+    sourceCompatibility = "17"
+    targetCompatibility = "17"
 
     ajc {
         enabled = true

--- a/examples/powertools-examples-core-utilities/gradle/template.yaml
+++ b/examples/powertools-examples-core-utilities/gradle/template.yaml
@@ -9,7 +9,7 @@ Description: >
 Globals:
   Function:
     Timeout: 20
-    Runtime: java11
+    Runtime: java17
     MemorySize: 512
     Tracing: Active # https://docs.aws.amazon.com/lambda/latest/dg/lambda-x-ray.html
     Environment:
@@ -26,7 +26,7 @@ Resources:
     Properties:
       CodeUri: .
       Handler: helloworld.App::handleRequest
-      Runtime: java11
+      Runtime: java17
       MemorySize: 512
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
@@ -43,7 +43,7 @@ Resources:
     Properties:
       CodeUri: .
       Handler: helloworld.AppStream::handleRequest
-      Runtime: java11
+      Runtime: java17
       MemorySize: 512
       Tracing: Active
       Environment:

--- a/examples/powertools-examples-core-utilities/kotlin/README.md
+++ b/examples/powertools-examples-core-utilities/kotlin/README.md
@@ -1,7 +1,7 @@
 #  Powertools for AWS Lambda (Kotlin) - Core Utilities Example
 
 This project demonstrates the Lambda for Powertools Kotlin module deployed using [Serverless Application Model](https://aws.amazon.com/serverless/sam/) with
-[Gradle](https://gradle.org/) running the build. This example is configured for Java 11 only; in order to use a newer version, check out the Gradle 
+[Gradle](https://gradle.org/) running the build. This example is configured for Java 17 only; in order to use a newer version, check out the Gradle 
 configuration guide [in the main project README](../../../README.md).
 
 You can also use `sam init` to create a new Gradle-powered Powertools application - choose to use the **AWS Quick Start Templates**,

--- a/examples/powertools-examples-core-utilities/kotlin/build.gradle.kts
+++ b/examples/powertools-examples-core-utilities/kotlin/build.gradle.kts
@@ -22,5 +22,5 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(17)
 }

--- a/examples/powertools-examples-core-utilities/kotlin/template.yaml
+++ b/examples/powertools-examples-core-utilities/kotlin/template.yaml
@@ -9,7 +9,7 @@ Description: >
 Globals:
   Function:
     Timeout: 20
-    Runtime: java11
+    Runtime: java17
     MemorySize: 512
     Tracing: Active # https://docs.aws.amazon.com/lambda/latest/dg/lambda-x-ray.html
     Environment:
@@ -26,7 +26,7 @@ Resources:
     Properties:
       CodeUri: .
       Handler: helloworld.App::handleRequest
-      Runtime: java11
+      Runtime: java17
       MemorySize: 512
       Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
         Variables:
@@ -43,7 +43,7 @@ Resources:
     Properties:
       CodeUri: .
       Handler: helloworld.AppStream::handleRequest
-      Runtime: java11
+      Runtime: java17
       MemorySize: 512
       Tracing: Active
       Environment:

--- a/examples/powertools-examples-core-utilities/sam-bazel/BUILD.bazel
+++ b/examples/powertools-examples-core-utilities/sam-bazel/BUILD.bazel
@@ -49,7 +49,7 @@ genrule(
             -inpath "$$BASE_JAR" \
             -aspectpath "$$POWERTOOLS_JARS" \
             -outjar $(location powertools_sam_lib_woven.jar) \
-            -source 11 -target 11 -nowarn
+            -source 17 -target 17 -nowarn
     """,
 )
 

--- a/examples/powertools-examples-core-utilities/sam-bazel/template.yaml
+++ b/examples/powertools-examples-core-utilities/sam-bazel/template.yaml
@@ -7,7 +7,7 @@ Description: >
 Globals:
   Function:
     Timeout: 20
-    Runtime: java11
+    Runtime: java17
     MemorySize: 512
     Tracing: Active # https://docs.aws.amazon.com/lambda/latest/dg/lambda-x-ray.html
     Environment:

--- a/examples/powertools-examples-core-utilities/sam-graalvm/pom.xml
+++ b/examples/powertools-examples-core-utilities/sam-graalvm/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <log4j.version>2.26.0</log4j.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <aspectj.version>1.9.20.1</aspectj.version>
     </properties>
 

--- a/examples/powertools-examples-core-utilities/sam/pom.xml
+++ b/examples/powertools-examples-core-utilities/sam/pom.xml
@@ -9,8 +9,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <aspectj.version>1.9.20.1</aspectj.version>
     </properties>
 

--- a/examples/powertools-examples-core-utilities/sam/template.yaml
+++ b/examples/powertools-examples-core-utilities/sam/template.yaml
@@ -7,7 +7,7 @@ Description: >
 Globals:
   Function:
     Timeout: 20
-    Runtime: java11
+    Runtime: java17
     MemorySize: 512
     Tracing: Active # https://docs.aws.amazon.com/lambda/latest/dg/lambda-x-ray.html
     Environment:

--- a/examples/powertools-examples-core-utilities/serverless/pom.xml
+++ b/examples/powertools-examples-core-utilities/serverless/pom.xml
@@ -9,8 +9,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <aspectj.version>1.9.20.1</aspectj.version>
     </properties>
 

--- a/examples/powertools-examples-core-utilities/serverless/serverless.yml
+++ b/examples/powertools-examples-core-utilities/serverless/serverless.yml
@@ -9,7 +9,7 @@ frameworkVersion: '3'
 
 provider:
   name: aws
-  runtime: java11
+  runtime: java17
 
 # you can overwrite defaults here
 #  stage: dev

--- a/examples/powertools-examples-core-utilities/terraform/infra/lambda.tf
+++ b/examples/powertools-examples-core-utilities/terraform/infra/lambda.tf
@@ -1,5 +1,5 @@
 resource "aws_lambda_function" "hello_world_lambda" {
-  runtime           = "java11"
+  runtime           = "java17"
   filename          = "target/helloworld-lambda.jar"
   source_code_hash  = filebase64sha256("target/helloworld-lambda.jar")
   function_name     = "hello_world_lambda"
@@ -16,7 +16,7 @@ resource "aws_lambda_function" "hello_world_lambda" {
 }
 
 resource "aws_lambda_function" "hello_world_stream_lambda" {
-  runtime           = "java11"
+  runtime           = "java17"
   filename          = "target/helloworld-lambda.jar"
   source_code_hash  = filebase64sha256("target/helloworld-lambda.jar")
   function_name     = "hello_world_stream_lambda"

--- a/examples/powertools-examples-core-utilities/terraform/pom.xml
+++ b/examples/powertools-examples-core-utilities/terraform/pom.xml
@@ -9,8 +9,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <aspectj.version>1.9.20.1</aspectj.version>
     </properties>
 

--- a/examples/powertools-examples-idempotency/sam-graalvm/pom.xml
+++ b/examples/powertools-examples-idempotency/sam-graalvm/pom.xml
@@ -8,8 +8,8 @@
     <name>Powertools for AWS Lambda (Java) - Examples - Idempotency GraalVM</name>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <aspectj.version>1.9.20.1</aspectj.version>
     </properties>
 

--- a/examples/powertools-examples-idempotency/sam/pom.xml
+++ b/examples/powertools-examples-idempotency/sam/pom.xml
@@ -23,8 +23,8 @@
     <name>Powertools for AWS Lambda (Java) - Examples - Idempotency</name>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <aspectj.version>1.9.20.1</aspectj.version>
     </properties>
 

--- a/examples/powertools-examples-idempotency/sam/template.yaml
+++ b/examples/powertools-examples-idempotency/sam/template.yaml
@@ -6,7 +6,7 @@ Description: >
 Globals:
   Function:
     Timeout: 20
-    Runtime: java11
+    Runtime: java17
     MemorySize: 512
     Tracing: Active
     Environment:

--- a/examples/powertools-examples-kafka/README.md
+++ b/examples/powertools-examples-kafka/README.md
@@ -15,7 +15,7 @@ Each format has its own Lambda function handler that demonstrates how to use the
 
 ### Prerequisites
 - [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
-- Java 11+
+- Java 17+
 - Maven
 
 ### Build

--- a/examples/powertools-examples-kafka/pom.xml
+++ b/examples/powertools-examples-kafka/pom.xml
@@ -8,8 +8,8 @@
     <name>Powertools for AWS Lambda (Java) - Examples - Kafka</name>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <aspectj.version>1.9.20.1</aspectj.version>
         <avro.version>1.12.1</avro.version>
         <protobuf.version>4.35.0</protobuf.version>

--- a/examples/powertools-examples-kafka/template.yaml
+++ b/examples/powertools-examples-kafka/template.yaml
@@ -6,7 +6,7 @@ Description: >
 Globals:
   Function:
     Timeout: 20
-    Runtime: java11
+    Runtime: java17
     MemorySize: 512
     Tracing: Active
 

--- a/examples/powertools-examples-kafka/tools/pom.xml
+++ b/examples/powertools-examples-kafka/tools/pom.xml
@@ -9,8 +9,8 @@
     <version>2.0.0</version>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <avro.version>1.12.1</avro.version>
         <protobuf.version>4.31.0</protobuf.version>
         <kafka-clients.version>4.0.2</kafka-clients.version>

--- a/examples/powertools-examples-parameters/sam-graalvm/pom.xml
+++ b/examples/powertools-examples-parameters/sam-graalvm/pom.xml
@@ -9,8 +9,8 @@
 
     <properties>
         <log4j.version>2.26.0</log4j.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <aspectj.version>1.9.20.1</aspectj.version>
     </properties>
 

--- a/examples/powertools-examples-parameters/sam/pom.xml
+++ b/examples/powertools-examples-parameters/sam/pom.xml
@@ -8,8 +8,8 @@
     <name>Powertools for AWS Lambda (Java) - Examples - Parameters</name>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <aspectj.version>1.9.20.1</aspectj.version>
     </properties>
 

--- a/examples/powertools-examples-parameters/sam/template.yaml
+++ b/examples/powertools-examples-parameters/sam/template.yaml
@@ -6,7 +6,7 @@ Description: >
 Globals:
   Function:
     Timeout: 20
-    Runtime: java11
+    Runtime: java17
     MemorySize: 512
     Tracing: Active
 

--- a/examples/powertools-examples-serialization/sam-graalvm/pom.xml
+++ b/examples/powertools-examples-serialization/sam-graalvm/pom.xml
@@ -8,8 +8,8 @@
     <name>Powertools for AWS Lambda (Java) - Examples - Serialization GraalVM</name>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/examples/powertools-examples-serialization/sam/pom.xml
+++ b/examples/powertools-examples-serialization/sam/pom.xml
@@ -8,8 +8,8 @@
     <name>Powertools for AWS Lambda (Java) - Examples - Serialization</name>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/examples/powertools-examples-serialization/sam/template.yaml
+++ b/examples/powertools-examples-serialization/sam/template.yaml
@@ -6,7 +6,7 @@ Description: >
 Globals:
   Function:
     Timeout: 20
-    Runtime: java11
+    Runtime: java17
     MemorySize: 512
     Tracing: Active
 

--- a/examples/powertools-examples-validation/pom.xml
+++ b/examples/powertools-examples-validation/pom.xml
@@ -22,8 +22,8 @@
     <name>Powertools for AWS Lambda (Java) - Examples - Validation</name>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <aspectj.version>1.9.20.1</aspectj.version>
     </properties>
 

--- a/examples/powertools-examples-validation/template.yaml
+++ b/examples/powertools-examples-validation/template.yaml
@@ -6,7 +6,7 @@ Description: >
 Globals:
   Function:
     Timeout: 20
-    Runtime: java11
+    Runtime: java17
     MemorySize: 512
     Tracing: Active
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,8 +80,8 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <maven.deploy.plugin.version>3.1.2</maven.deploy.plugin.version>
         <log4j.version>2.26.0</log4j.version>
         <slf4j.version>2.0.17</slf4j.version>
@@ -94,7 +94,7 @@
         <lambda.events.version>3.16.1</lambda.events.version>
         <lambda.serial.version>1.3.1</lambda.serial.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-        <aspectj.version>1.9.7</aspectj.version>
+        <aspectj.version>1.9.20.1</aspectj.version>
         <aspectj-maven-plugin.version>1.13.1</aspectj-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>

--- a/powertools-e2e-tests/README.md
+++ b/powertools-e2e-tests/README.md
@@ -6,10 +6,10 @@ This module is internal and meant to be used for end-to-end (E2E) testing of Pow
 
 - An AWS account is needed as well as a local environment able to reach this account
   ([credentials](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html)).
-- [Java 11+](https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/downloads-list.html)
+- [Java 17+](https://docs.aws.amazon.com/corretto/latest/corretto-17-ug/downloads-list.html)
 - [Docker](https://docs.docker.com/engine/install/) (or [Finch](https://github.com/runfinch/finch) — if using Finch, set `export CDK_DOCKER=finch` before running tests)
 
-To execute the E2E tests, use the following command: `export JAVA_VERSION=11 && mvn clean verify -Pe2e`
+To execute the E2E tests, use the following command: `export JAVA_VERSION=17 && mvn clean verify -Pe2e`
 
 ### Under the hood
 

--- a/powertools-e2e-tests/handlers/pom.xml
+++ b/powertools-e2e-tests/handlers/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <lambda.java.core>1.4.0</lambda.java.core>
         <lambda.java.serialization>1.3.1</lambda.java.serialization>
         <lambda.java.events>3.16.1</lambda.java.events>
@@ -243,15 +243,6 @@
 
     <profiles>
         <!-- https://github.com/eclipse-aspectj/aspectj/blob/master/docs/dist/doc/JavaVersionCompatibility.md -->
-        <profile>
-            <id>jdk11to16</id>
-            <activation>
-                <jdk>[11,16]</jdk>
-            </activation>
-            <properties>
-                <aspectj.version>1.9.7</aspectj.version>
-            </properties>
-        </profile>
         <profile>
             <id>jdk17to20</id>
             <activation>

--- a/powertools-e2e-tests/pom.xml
+++ b/powertools-e2e-tests/pom.xml
@@ -28,8 +28,8 @@
     <description>Powertools for AWS Lambda (Java) – End-To-End Tests</description>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <constructs.version>10.6.0</constructs.version>
         <cdk.version>2.258.0</cdk.version>
     </properties>

--- a/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/testutils/Infrastructure.java
+++ b/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/testutils/Infrastructure.java
@@ -16,6 +16,7 @@ package software.amazon.lambda.powertools.testutils;
 
 import static java.util.Collections.singletonList;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -24,13 +25,9 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
-
-import com.fasterxml.jackson.databind.JsonNode;
-
 import software.amazon.awscdk.App;
 import software.amazon.awscdk.BundlingOptions;
 import software.amazon.awscdk.CfnOutput;
@@ -516,9 +513,7 @@ public final class Infrastructure {
             if (javaVersion == null) {
                 throw new IllegalArgumentException(environmentVariableName + " is not set");
             }
-            if (javaVersion.startsWith("11")) {
-                ret = JavaRuntime.JAVA11;
-            } else if (javaVersion.startsWith("17")) {
+            if (javaVersion.startsWith("17")) {
                 ret = JavaRuntime.JAVA17;
             } else if (javaVersion.startsWith("21")) {
                 ret = JavaRuntime.JAVA21;

--- a/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/testutils/JavaRuntime.java
+++ b/powertools-e2e-tests/src/test/java/software/amazon/lambda/powertools/testutils/JavaRuntime.java
@@ -17,7 +17,6 @@ package software.amazon.lambda.powertools.testutils;
 import software.amazon.awscdk.services.lambda.Runtime;
 
 public enum JavaRuntime {
-    JAVA11("java11", Runtime.JAVA_11, "11"),
     JAVA17("java17", Runtime.JAVA_17, "17"),
     JAVA21("java21", Runtime.JAVA_21, "21"),
     JAVA25("java25", Runtime.JAVA_25, "25");


### PR DESCRIPTION
Issue number: Closes #2457 

## Description of changes:
<!--- One or two sentences as a summary of what's being changed -->
- Update all examples, dependencies, and documentation to use Java 17 as the minimum supported version.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
